### PR TITLE
Add ability to pass in session token (Fixes #27, SPL-50973)

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -140,9 +140,9 @@ class Context(object):
                        instance.
     :param `handler`: The HTTP request handler (optional).
     """
-    def __init__(self, handler=None, **kwargs):
+    def __init__(self, handler=None, **kwargs):        
         self.http = HttpLib(handler)
-        self.token = None
+        self.token = kwargs.get("token", None)
         self.prefix = prefix(**kwargs)
         self.scheme = kwargs.get("scheme", DEFAULT_SCHEME)
         self.host = kwargs.get("host", DEFAULT_HOST)

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -359,5 +359,29 @@ class TestCase(testlib.TestCase):
 
         context.delete(PATH_USERS + username)
         
+    # Verify that we can pass a pre-existing token
+    def test_preexisting_token(self):
+        context = binding.connect(**self.opts.kwargs)
+        token = context.token
+        
+        # Ensure the context works
+        response = context.get("/services")
+        self.assertEqual(response.status, 200)
+        
+        # Create a new opts dictionary and stash the token there
+        opts = self.opts.kwargs.copy()
+        opts["token"] = token
+        
+        # We create a new context
+        newContext = binding.Context(**opts)
+        
+        # Ensure the new context works
+        response = newContext.get("/services")
+        self.assertEqual(response.status, 200)
+        
+        # Make sure we can open a socket to the service
+        context.connect().close()
+        newContext.connect().close()
+        
 if __name__ == "__main__":
     testlib.main()


### PR DESCRIPTION
Until now, you could not pass a pre-existing token to Context, which
would mean that in turn, you always had to log in. This change fixes
this and adds a test to make sure we don't break it.
