### PR TITLE
All tests now pace with 4.3.3 and Ace.

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,7 +20,7 @@ import logging
 import splunklib.client as client
 import splunklib.data as data
 
-class TestApp(testlib.TestCase):
+class TestApp(testlib.SDKTestCase):
     app = None
     app_name = None
     def setUp(self):

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -400,7 +400,7 @@ def isatom(body):
         root.find(XNAME_ID) is not None and \
         root.find(XNAME_TITLE) is not None
 
-class TestPluggableHTTP(testlib.TestCase):
+class TestPluggableHTTP(testlib.SDKTestCase):
     # Verify pluggable HTTP reqeust handlers.
     def test_handlers(self):
         paths = ["/services", "authentication/users", 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -37,9 +37,9 @@ expected_access_keys = set(['sharing', 'app', 'owner'])
 expected_fields_keys = set(['required', 'optional', 'wildcard'])
 
 
-class TestCase(testlib.TestCase):
+class CollectionTestCase(testlib.SDKTestCase):
     def setUp(self):
-        super(TestCase, self).setUp()
+        super(CollectionTestCase, self).setUp()
         if self.service.splunk_version[0] >= 5 and 'modular_input_kinds' not in collections:
             collections.append('modular_input_kinds') # Not supported before Splunk 5.0
         else:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -19,7 +19,7 @@ import logging
 
 import splunklib.client as client
 
-class TestRead(testlib.TestCase):
+class TestRead(testlib.SDKTestCase):
     def test_read(self):
         service = client.connect(**self.opts.kwargs)
 
@@ -36,7 +36,7 @@ class TestRead(testlib.TestCase):
         for stanza in confs['indexes'].list(count=5):
             self.check_entity(stanza)
 
-class TestConfs(testlib.TestCase):
+class TestConfs(testlib.SDKTestCase):
     def setUp(self):
         super(TestConfs, self).setUp()
         self.app_name = testlib.tmpname()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -21,7 +21,7 @@ import testlib
 
 import splunklib.data as data
 
-class TestCase(testlib.TestCase):
+class DataTestCase(testlib.SDKTestCase):
     def test_elems(self):
         result = data.load("")
         self.assertTrue(result is None)

--- a/tests/test_event_type.py
+++ b/tests/test_event_type.py
@@ -19,12 +19,12 @@ import logging
 
 import splunklib.client as client
 
-class TestRead(testlib.TestCase):
+class TestRead(testlib.SDKTestCase):
     def test_read(self):
         for event_type in self.service.event_types.list(count=1):
             self.check_entity(event_type)
 
-class TestCreate(testlib.TestCase):
+class TestCreate(testlib.SDKTestCase):
     def test_create(self):
         self.event_type_name = testlib.tmpname()
         event_types = self.service.event_types
@@ -47,7 +47,7 @@ class TestCreate(testlib.TestCase):
         except KeyError:
             pass
 
-class TestEventType(testlib.TestCase):
+class TestEventType(testlib.SDKTestCase):
     def setUp(self):
         super(TestEventType, self).setUp()
         self.event_type_name = testlib.tmpname()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+#
+# Copyright 2011-2012 Splunk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"): you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+from subprocess import PIPE, Popen
+import time
+import sys
+
+import testlib 
+
+import splunklib.client as client
+
+def check_multiline(testcase, first, second, message=None):
+    """Assert that two multi-line strings are equal."""
+    testcase.assertTrue(isinstance(first, basestring), 
+        'First argument is not a string')
+    testcase.assertTrue(isinstance(second, basestring), 
+        'Second argument is not a string')
+    # Unix-ize Windows EOL
+    first = first.replace("\r", "")
+    second = second.replace("\r", "")
+    if first != second:
+        testcase.fail("Multiline strings are not equal: %s" % message)
+
+# Run the given python script and return its exit code. 
+def run(script, stdin=None, stdout=PIPE, stderr=None):
+    process = start(script, stdin, stdout, stderr)
+    process.communicate()
+    return process.wait()
+
+# Start the given python script and return the corresponding process object.
+# The script can be specified as either a string or arg vector. In either case
+# it will be prefixed to invoke python explicitly.
+def start(script, stdin=None, stdout=PIPE, stderr=None):
+    if isinstance(script, str):
+        script = script.split()
+    script = ["python"] + script
+    return Popen(script, stdin=stdin, stdout=stdout, stderr=stderr, cwd='../examples')
+
+# Rudimentary sanity check for each of the examples
+class ExamplesTestCase(testlib.SDKTestCase):
+    def check_commands(self, *args):
+        for arg in args: 
+            self.assertEquals(run(arg), 0)
+
+    def setUp(self):
+        super(ExamplesTestCase, self).setUp()
+
+        # Ignore result, it might already exist
+        run("index.py create sdk-tests")
+
+    def test_async(self):
+        result = run("async/async.py sync")
+        self.assertEquals(result, 0)
+
+        try:
+            # Only try running the async version of the test if eventlet
+            # is present on the system
+            import eventlet
+            result = run("async/async.py async")
+            self.assertEquals(result, 0)
+        except:
+            pass
+
+    def test_binding1(self):
+        result = run("binding1.py")
+        self.assertEquals(result, 0)
+
+    def test_conf(self):
+        self.check_commands(
+            "conf.py --help",
+            "conf.py",
+            "conf.py viewstates",
+            'conf.py --app=search --owner=admin viewstates',
+            "conf.py create server SDK-STANZA",
+            "conf.py create server SDK-STANZA testkey=testvalue",
+            "conf.py delete server SDK-STANZA")
+
+    def test_event_types(self):
+        self.check_commands(
+            "event_types.py --help",
+            "event_types.py")
+        
+    def test_fired_alerts(self):
+        self.check_commands(
+            "fired_alerts.py --help",
+            "fired_alerts.py")
+        
+    def test_follow(self):
+        self.check_commands("follow.py --help")
+
+    def test_handlers(self):
+        self.check_commands(
+            "handlers/handler_urllib2.py",
+            "handlers/handler_debug.py",
+            "handlers/handler_certs.py",
+            "handlers/handler_certs.py --ca_file=handlers/cacert.pem",
+            "handlers/handler_proxy.py --help")
+
+        # Run the cert handler example with a bad cert file, should error.
+        result = run(
+            "handlers/handlers_certs.py --ca_file=handlers/cacert.bad.pem", 
+            stderr=PIPE)
+        self.assertNotEquals(result, 0)
+
+        # The proxy handler example requires that there be a proxy available
+        # to relay requests, so we spin up a local proxy using the proxy
+        # script included with the sample.
+
+        # Assumes that tiny-proxy.py is in the same directory as the sample
+        process = start("handlers/tiny-proxy.py -p 8080", stderr=PIPE)
+        try:
+            time.sleep(2) # Wait for proxy to finish initializing
+            result = run("handlers/handler_proxy.py --proxy=localhost:8080")
+            self.assertEquals(result, 0)
+        finally:
+            process.kill()
+
+        # Run it again without the proxy and it should fail.
+        result = run(
+            "handlers/handler_proxy.py --proxy=localhost:80801", stderr=PIPE)
+        self.assertNotEquals(result, 0)
+
+    def test_index(self):
+        self.check_commands(
+            "index.py --help",
+            "index.py",
+            "index.py list",
+            "index.py list sdk-tests",
+            "index.py disable sdk-tests",
+            "index.py enable sdk-tests",
+            "index.py clean sdk-tests")
+
+    def test_info(self):
+        self.check_commands(
+            "info.py --help",
+            "info.py")
+
+    def test_inputs(self):
+        self.check_commands(
+            "inputs.py --help",
+            "inputs.py")
+        
+    def test_job(self):
+        self.check_commands(
+            "job.py --help",
+            "job.py",
+            "job.py list",
+            "job.py list @0")
+        
+    def test_loggers(self):
+        self.check_commands(
+            "loggers.py --help",
+            "loggers.py")
+
+    def test_oneshot(self):
+        self.check_commands(["oneshot.py", "search * | head 10"])
+
+    def test_saved_searches(self):
+        self.check_commands(
+            "saved_searches.py --help",
+            "saved_searches.py")
+        
+    def test_search(self):
+        self.check_commands(
+            "search.py --help",
+            ["search.py", "search * | head 10"],
+            ["search.py", 
+             "search * | head 10 | stats count", '--output_mode=csv'])
+
+    def test_spcmd(self):
+        self.check_commands(
+            "spcmd.py --help",
+            "spcmd.py -e\"get('authentication/users')\"")
+
+    def test_spurl(self):
+        self.check_commands(
+            "spurl.py --help",
+            "spurl.py",
+            "spurl.py /services",
+            "spurl.py apps/local")
+
+    def test_submit(self):
+        self.check_commands("submit.py --help")
+
+    def test_upload(self):
+        # Note: test must run on machine where splunkd runs,
+        # or a failure is expected
+        self.check_commands(
+            "upload.py --help",
+            "upload.py --index=sdk-tests ./upload.py")
+
+    # The following tests are for the custom_search examples. The way
+    # the tests work mirrors how Splunk would invoke them: they pipe in
+    # a known good input file into the custom search python file, and then
+    # compare the resulting output file to a known good one.
+    def test_custom_search(self):
+
+        def test_custom_search_command(script, input_path, baseline_path):
+            output_base, _ = os.path.splitext(input_path)
+            output_path = output_base + ".out"
+            output_file = open(output_path, 'w')
+
+            input_file = open(input_path, 'r')
+
+            # Execute the command
+            result = run(script, stdin=input_file, stdout=output_file)
+            self.assertEquals(result, 0)
+
+            input_file.close()
+            output_file.close()
+
+            # Make sure the test output matches the baseline
+            baseline_file = open(baseline_path, 'r')
+            baseline = baseline_file.read()
+
+            output_file = open(output_path, 'r')
+            output = output_file.read()
+
+            message = "%s != %s" % (output_file.name, baseline_file.name)
+            check_multiline(self, baseline, output, message)
+
+            # Cleanup
+            baseline_file.close()
+            output_file.close()
+            os.remove(output_path)
+
+        custom_searches = [ 
+            {
+                "script": "custom_search/bin/usercount.py",
+                "input": "../tests/custom_search/usercount.in",
+                "baseline": "../tests/custom_search/usercount.baseline"
+            },
+            { 
+                "script": "twitted/twitted/bin/hashtags.py",
+                "input": "../tests/custom_search/hashtags.in",
+                "baseline": "../tests/custom_search/hashtags.baseline"
+            },
+            { 
+                "script": "twitted/twitted/bin/tophashtags.py",
+                "input": "../tests/custom_search/tophashtags.in",
+                "baseline": "../tests/custom_search/tophashtags.baseline"
+            }
+        ]
+
+        for custom_search in custom_searches:
+            test_custom_search_command(
+                custom_search['script'],
+                custom_search['input'],
+                custom_search['baseline'])
+
+    # The following tests are for the Analytics example
+    def test_analytics(self):
+        # We have to add the current path to the PYTHONPATH,
+        # otherwise the import doesn't work quite right
+        sys.path.append(os.getcwd())
+        import analytics
+
+        # Create a tracker
+        tracker = analytics.input.AnalyticsTracker(
+            "sdk-test", self.opts.kwargs, index = "sdk-test")
+
+        service = client.connect(**self.opts.kwargs)
+
+        # Before we start, we'll clean the index
+        index = service.indexes["sdk-test"]
+        index.clean()
+        
+        tracker.track("test_event", distinct_id="abc123", foo="bar", abc="123")
+        tracker.track("test_event", distinct_id="123abc", abc="12345")
+
+        # Wait until the events get indexed
+        testlib.wait(index, lambda index: index['totalEventCount'] == '2')
+
+        # Now, we create a retriever to retrieve the events
+        retriever = analytics.output.AnalyticsRetriever(
+            "sdk-test", self.opts.kwargs, index = "sdk-test")    
+        
+        # Assert applications
+        applications = retriever.applications()
+        self.assertEquals(len(applications), 1)
+        self.assertEquals(applications[0]["name"], "sdk-test")
+        self.assertEquals(applications[0]["count"], 2)
+
+        # Assert events
+        events = retriever.events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["name"], "test_event")
+        self.assertEqual(events[0]["count"], 2)
+
+        # Assert properties
+        expected_properties = {
+            "abc": 2,
+            "foo": 1
+        }
+        properties = retriever.properties("test_event")
+        self.assertEqual(len(properties), len(expected_properties))
+        for prop in properties:
+            name = prop["name"]
+            count = prop["count"]
+            self.assertTrue(name in expected_properties.keys())
+            self.assertEqual(count, expected_properties[name])
+
+        # Assert property values
+        expected_property_values = {
+            "123": 1,
+            "12345": 1
+        }
+        values = retriever.property_values("test_event", "abc")
+        self.assertEqual(len(values), len(expected_property_values))
+        for value in values:
+            name = value["name"]
+            count = value["count"]
+            self.assertTrue(name in expected_property_values.keys())
+            self.assertEqual(count, expected_property_values[name])
+            
+        # Assert event over time
+        over_time = retriever.events_over_time(
+            time_range = analytics.output.TimeRange.MONTH)
+        self.assertEquals(len(over_time), 1)
+        self.assertEquals(len(over_time["test_event"]), 1)
+        self.assertEquals(over_time["test_event"][0]["count"], 2)
+
+        # Now that we're done, we'll clean the index 
+        index.clean()
+ 
+if __name__ == "__main__":
+    os.chdir("../examples")
+    testlib.main()

--- a/tests/test_fired_alert.py
+++ b/tests/test_fired_alert.py
@@ -19,9 +19,9 @@ import logging
 
 import splunklib.client as client
 
-class TestCase(testlib.TestCase):
+class FiredAlertTestCase(testlib.SDKTestCase):
     def setUp(self):
-        super(TestCase, self).setUp()
+        super(FiredAlertTestCase, self).setUp()
         self.index_name = testlib.tmpname()
         self.assertFalse(self.index_name in self.service.indexes)
         self.index = self.service.indexes.create(self.index_name)
@@ -44,7 +44,7 @@ class TestCase(testlib.TestCase):
             query, **kwargs)
 
     def tearDown(self):
-        super(TestCase, self).tearDown()
+        super(FiredAlertTestCase, self).tearDown()
         for saved_search in self.service.saved_searches:
             if saved_search.name.startswith('delete-me'):
                 self.service.saved_searches.delete(saved_search.name)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -19,7 +19,7 @@ import logging
 
 import splunklib.client as client
 
-class TestRead(testlib.TestCase):
+class TestRead(testlib.SDKTestCase):
     def test_read(self):
         inputs = self.service.inputs
         # count doesn't work on inputs; known problem tested for in
@@ -78,7 +78,7 @@ class TestRead(testlib.TestCase):
             self.service.inputs.oneshot, name)
 
 
-class TestInput(testlib.TestCase):
+class TestInput(testlib.SDKTestCase):
     def setUp(self):
         super(TestInput, self).setUp()
         inputs = self.service.inputs

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -24,7 +24,7 @@ import splunklib.results as results
 
 from splunklib.binding import log_duration
 
-class TestUtilities(testlib.TestCase):
+class TestUtilities(testlib.SDKTestCase):
     def test_service_search(self):
         job = self.service.search('search index=_internal earliest=-1m | head 3')
         self.assertTrue(self.service.jobs.contains(job.sid))
@@ -140,7 +140,7 @@ class TestUtilities(testlib.TestCase):
             self.check_job(job)
 
 
-class TestJob(testlib.TestCase):
+class TestJob(testlib.SDKTestCase):
     def setUp(self):
         super(TestJob, self).setUp()
         self.query = "search index=_internal earliest=-1m | head 3"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -20,7 +20,7 @@ import splunklib.client as client
 
 LEVELS = ["INFO", "WARN", "ERROR", "DEBUG", "CRIT"]
 
-class TestCase(testlib.TestCase):
+class LoggerTestCase(testlib.SDKTestCase):
     def check_logger(self, logger):
         self.check_entity(logger)
         self.assertTrue(logger['level'] in LEVELS)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -18,19 +18,19 @@ import testlib
 
 import splunklib.client as client
 
-class MessageTest(testlib.TestCase):
+class MessageTest(testlib.SDKTestCase):
     def setUp(self):
-        testlib.TestCase.setUp(self)
+        testlib.SDKTestCase.setUp(self)
         self.message_name = testlib.tmpname()
         self.message = self.service.messages.create(
             self.message_name,
             value='Test message created by the SDK')
 
     def tearDown(self):
-        testlib.TestCase.tearDown(self)
+        testlib.SDKTestCase.tearDown(self)
         self.service.messages.delete(self.message_name)
 
-class TestCreateDelete(testlib.TestCase):
+class TestCreateDelete(testlib.SDKTestCase):
     def test_create_delete(self):
         message_name = testlib.tmpname()
         message_value = 'Test message'

--- a/tests/test_modular_input_kinds.py
+++ b/tests/test_modular_input_kinds.py
@@ -17,7 +17,7 @@
 import testlib
 import splunklib.client as client
 
-class ModularInputKindTestCase(testlib.TestCase):
+class ModularInputKindTestCase(testlib.SDKTestCase):
     def test_list_arguments(self):
         if self.service.splunk_version[0] < 5:
             # Not implemented before 5.0

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -20,7 +20,7 @@ import testlib
 
 import splunklib.results as results
 
-class TestCase(testlib.TestCase):
+class ResultsTestCase(testlib.SDKTestCase):
     def test_read_normal_results(self):
         xml_text = """
 <?xml version='1.0' encoding='UTF-8'?>

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -19,14 +19,14 @@ import logging
 
 import splunklib.client as client
 
-class TestCase(testlib.TestCase):
+class RoleTestCase(testlib.SDKTestCase):
     def setUp(self):
-        super(TestCase, self).setUp()
+        super(RoleTestCase, self).setUp()
         self.role_name = testlib.tmpname()
         self.role = self.service.roles.create(self.role_name)
 
     def tearDown(self):
-        super(TestCase, self).tearDown()
+        super(RoleTestCase, self).tearDown()
         for role in self.service.roles:
             if role.name.startswith('delete-me'):
                 self.service.roles.delete(role.name)

--- a/tests/test_saved_search.py
+++ b/tests/test_saved_search.py
@@ -22,7 +22,7 @@ from time import sleep
 
 import splunklib.client as client
 
-class TestSavedSearch(testlib.TestCase):
+class TestSavedSearch(testlib.SDKTestCase):
     def setUp(self):
         super(TestSavedSearch, self).setUp()
         saved_searches = self.service.saved_searches

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24,7 +24,7 @@ import splunklib.data as data
 import splunklib.client as client
 from splunklib.binding import HTTPError
 
-class TestCase(testlib.TestCase):
+class ServiceTestCase(testlib.SDKTestCase):
     def test_capabilities(self):
         capabilities = self.service.capabilities
         self.assertTrue(isinstance(capabilities, list))
@@ -101,7 +101,7 @@ class TestCase(testlib.TestCase):
         for p in v:
             self.assertTrue(isinstance(p, int) and p >= 0)
 
-class TestSettings(testlib.TestCase):
+class TestSettings(testlib.SDKTestCase):
     def test_read_settings(self):
         settings = self.service.settings
         # Verify that settings contains the keys we expect

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -19,14 +19,14 @@ import logging
 
 import splunklib.client as client
 
-class TestCase(testlib.TestCase):
+class UserTestCase(testlib.SDKTestCase):
     def check_user(self, user):
         self.check_entity(user)
         # Verify expected fields exist
         [user[f] for f in ['email', 'password', 'realname', 'roles']]
         
     def setUp(self):
-        super(TestCase, self).setUp()
+        super(UserTestCase, self).setUp()
         self.username = testlib.tmpname()
         self.user = self.service.users.create(
             self.username,
@@ -34,7 +34,7 @@ class TestCase(testlib.TestCase):
             roles=['power', 'user'])
 
     def tearDown(self):
-        super(TestCase, self).tearDown()
+        super(UserTestCase, self).tearDown()
         for user in self.service.users:
             if user.name.startswith('delete-me'):
                 self.service.users.delete(user.name)

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -105,7 +105,7 @@ def wait(entity, predicate, timeout=60):
     logging.debug("wait finished after %s seconds", datetime.now()-start)
     return entity
 
-class TestCase(unittest.TestCase):
+class SDKTestCase(unittest.TestCase):
     def check_content(self, entity, **kwargs):
         for k, v in kwargs.iteritems(): 
             self.assertEqual(entity[k], str(v))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -63,6 +63,12 @@ RULES_SPLUNK = {
         'default': None,
         'help': "Password to login with" 
     },
+    # This is introduced for the Java SDK's test suite. It has
+    # to be here in order to share a single .splunkrc among the
+    # SDKs, but is not yet used in Python (though it will probably
+    # be used in future). It's optional, though, so we don't need
+    # to change the README or otherwise document it in the Python
+    # SDK for now.
     'appcollection': {
         'flags': ["--appcollection"],
         'default': None,


### PR DESCRIPTION
Last index test (Index.clean()) now disables on 4.x and not on >=5, and no longer gets a restart.
Modular input tests are skipped on 4.x.
Added appcollection field to .splunkrc parsing in anticipation of new, single item apps for testing things
not creatable with the REST API.
