### PR TITLE
Fixed things found in session 1 of the grand Python review.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0
 
+* Confs has been renamed to Configurations.
 * Stanza.submit now takes a dictionary of key/value pairs specifying the stanza instead of a raw string.
 * Namespace handling has changed subtly. Code that depends on namespace handling in detail may break.
 * Added User.role_entities to return a list of the actual entity objects for the

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -297,7 +297,7 @@ class TestInput(testlib.SDKTestCase):
                         inputs.delete, name)
                 self.service.inputs.delete(kind, name)
                 self.assertFalse((kind,name) in inputs)
-            self.assertRaises(client.EntityDeletedException,
+            self.assertRaises(client.HTTPError,
                               input_entity.refresh)
             remaining -= 1
 

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -57,7 +57,7 @@ class RoleTestCase(testlib.SDKTestCase):
         self.assertTrue(self.role_name in self.service.roles)
         self.service.roles.delete(self.role_name)
         self.assertFalse(self.role_name in self.service.roles)
-        self.assertRaises(client.EntityDeletedException, self.role.refresh)
+        self.assertRaises(client.HTTPError, self.role.refresh)
 
     def test_grant_and_revoke(self):
         self.assertFalse('edit_user' in self.role.capabilities)

--- a/tests/test_saved_search.py
+++ b/tests/test_saved_search.py
@@ -83,7 +83,7 @@ class TestSavedSearch(testlib.SDKTestCase):
         self.assertTrue(self.saved_search_name in self.service.saved_searches)
         self.service.saved_searches.delete(self.saved_search_name)
         self.assertFalse(self.saved_search_name in self.service.saved_searches)
-        self.assertRaises(client.EntityDeletedException,
+        self.assertRaises(client.HTTPError,
                           self.saved_search.refresh)
 
     

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -55,7 +55,7 @@ class UserTestCase(testlib.SDKTestCase):
     def test_delete(self):
         self.service.users.delete(self.username)
         self.assertFalse(self.username in self.service.users)
-        with self.assertRaises(client.EntityDeletedException):
+        with self.assertRaises(client.HTTPError):
             self.user.refresh()
 
     def test_update(self):


### PR DESCRIPTION
- Added a note that Confs as been renamed to Configurations in CHANGELOG.md.
- Entity.refresh no longer tries to interpret HTTPErrors, and just lets them bubble up. Fixed test_delete tests in test_input,
  test_role, test_saved_search, and test_user to expect HTTPError instead of EntityDeletedException. Deleted EntityDeletedException
  since it is not longer used.
- Fixed namespace logic in Entity._proper_namespace to draw on the entity's own namespace before the service's namespace.
- Moved AmbiguousReferenceException throwing from _load_state in Entity to _load_atom_entry (where it should be).
- Fixed doctoring of Service.search to indicate that it returns a Job, not the results of a oneshot search.
- Edited a comment that was too Freddian for public consumption.
- Moved URL-unquoting of links from refresh to read on Entity, and made it a UrlEncoded step instead of unencoding them.
