### PR TITLE
Add missing packages to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,10 @@ setup(
 
     name="splunk-sdk",
 
-    packages = ["splunklib"],
+    packages = ["splunklib",
+                "splunklib.modularinput",
+                "splunklib.searchcommands",
+                "splunklib.searchcommands.csv"],
 
     url="http://github.com/splunk/splunk-sdk-python",
 


### PR DESCRIPTION
Added `splunklib.modularinput`, `splunklib.searchcommands` and `splunklib.searchcommands.csv` to setup.py so they will be included when installed.
