### PR TITLE
Make ResponseReader more streamlike, so that it can be wrapped in a BufferedReader

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -29,6 +29,7 @@ import logging
 import socket
 import ssl
 import urllib
+import io
 
 from datetime import datetime
 from functools import wraps
@@ -1110,7 +1111,7 @@ class HttpLib(object):
 
 
 # Converts an httplib response into a file-like object.
-class ResponseReader(object):
+class ResponseReader(io.RawIOBase):
     """This class provides a file-like interface for :class:`httplib` responses.
 
     The ``ResponseReader`` class is intended to be a layer to unify the different
@@ -1163,6 +1164,23 @@ class ResponseReader(object):
             size -= len(r)
         r = r + self._response.read(size)
         return r
+
+    def readable(self):
+        """ Indicates that the response reader is readable."""
+        return True
+
+    def readinto(self, byte_array):
+        """ Read data into a byte array, upto the size of the byte array.
+
+        :param byte_array: A byte array/memory view to pour bytes into.
+        :type byte_array: ``bytearray`` or ``memoryview``
+
+        """
+        max_size = len(byte_array)
+        data = self.read(max_size)
+        bytes_read = len(data)
+        byte_array[:bytes_read] = data
+        return bytes_read
 
 
 def handler(key_file=None, cert_file=None, timeout=None):

--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -12,15 +12,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""The **splunklib.results** module provides a streaming XML reader for Splunk 
+"""The **splunklib.results** module provides a streaming XML reader for Splunk
 search results.
 
-Splunk search results can be returned in a variety of formats including XML, 
-JSON, and CSV. To make it easier to stream search results in XML format, they 
-are returned as a stream of XML *fragments*, not as a single XML document. This 
-module supports incrementally reading one result record at a time from such a 
+Splunk search results can be returned in a variety of formats including XML,
+JSON, and CSV. To make it easier to stream search results in XML format, they
+are returned as a stream of XML *fragments*, not as a single XML document. This
+module supports incrementally reading one result record at a time from such a
 result stream. This module also provides a friendly iterator-based interface for
-accessing search results while avoiding buffering the result set, which can be 
+accessing search results while avoiding buffering the result set, which can be
 very large.
 
 To use the reader, instantiate :class:`ResultsReader` on a search result stream
@@ -65,13 +65,13 @@ class Message(object):
     def __init__(self, type_, message):
         self.type = type_
         self.message = message
-    
+
     def __repr__(self):
         return "%s: %s" % (self.type, self.message)
-    
+
     def __eq__(self, other):
         return (self.type, self.message) == (other.type, other.message)
-    
+
     def __hash__(self):
         return hash((self.type, self.message))
 
@@ -149,18 +149,18 @@ class _XMLDTDFilter(object):
         return response
 
 class ResultsReader(object):
-    """This class returns dictionaries and Splunk messages from an XML results 
+    """This class returns dictionaries and Splunk messages from an XML results
     stream.
 
-    ``ResultsReader`` is iterable, and returns a ``dict`` for results, or a 
-    :class:`Message` object for Splunk messages. This class has one field, 
-    ``is_preview``, which is ``True`` when the results are a preview from a 
+    ``ResultsReader`` is iterable, and returns a ``dict`` for results, or a
+    :class:`Message` object for Splunk messages. This class has one field,
+    ``is_preview``, which is ``True`` when the results are a preview from a
     running search, or ``False`` when the results are from a completed search.
 
-    This function has no network activity other than what is implicit in the 
+    This function has no network activity other than what is implicit in the
     stream it operates on.
 
-    :param `stream`: The stream to read from (any object that supports 
+    :param `stream`: The stream to read from (any object that supports
         ``.read()``).
 
     **Example**::
@@ -224,7 +224,7 @@ class ResultsReader(object):
                         yield result
                         result = None
                         elem.clear()
-    
+
                 elif elem.tag == 'field' and result is not None:
                     # We need the 'result is not None' check because
                     # 'field' is also the element name in the <meta>
@@ -244,11 +244,11 @@ class ResultsReader(object):
                         # arbitrarily large memory intead of
                         # streaming.
                         elem.clear()
-    
+
                 elif elem.tag in ('text', 'v') and event == 'end':
                     values.append(elem.text.encode('utf8'))
                     elem.clear()
-    
+
                 elif elem.tag == 'msg':
                     if event == 'start':
                         msg_type = elem.attrib['type']

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -18,6 +18,7 @@ from StringIO import StringIO
 import testlib
 from time import sleep
 import splunklib.results as results
+import io
 
 
 class ResultsTestCase(testlib.SDKTestCase):
@@ -25,7 +26,7 @@ class ResultsTestCase(testlib.SDKTestCase):
         job = self.service.jobs.create("search index=_internal_does_not_exist | head 2")
         while not job.is_done():
             sleep(0.5)
-        self.assertEquals(0, len(list(results.ResultsReader(job.results()))))
+        self.assertEquals(0, len(list(results.ResultsReader(io.BufferedReader(job.results())))))
 
     def test_read_normal_results(self):
         xml_text = """
@@ -107,9 +108,9 @@ class ResultsTestCase(testlib.SDKTestCase):
                 'sum(kb)': '5838.935649',
             },
         ]
-        
+
         self.assert_parsed_results_equals(xml_text, expected_results)
-    
+
     def test_read_raw_field(self):
         xml_text = """
 <?xml version='1.0' encoding='UTF-8'?>
@@ -129,9 +130,9 @@ class ResultsTestCase(testlib.SDKTestCase):
                 '_raw': '07-13-2012 09:27:27.307 -0700 INFO  Metrics - group=search_concurrency, system total, active_hist_searches=0, active_realtime_searches=0',
             },
         ]
-        
+
         self.assert_parsed_results_equals(xml_text, expected_results)
-    
+
     def assert_parsed_results_equals(self, xml_text, expected_results):
         results_reader = results.ResultsReader(StringIO(xml_text))
         actual_results = [x for x in results_reader]


### PR DESCRIPTION
As per discussion in http://answers.splunk.com/answers/114045/python-sdk-resultsresultsreader-extremely-slow, I've attempted to make the `ResponseReader` more streamlike - this allows us to wrap it in an `io.BufferedReader` to realize a significant performance gain.
### Example usage

code before:

``` python
response = job.results(count=maxRecords, offset=self._offset)
resultsList = results.ResultsReader(response) 
```

Code after:

``` python
import io
...
response = job.results(count=maxRecords, offset=self._offset)
resultsList = results.ResultsReader(io.BufferedReader(response)) 
```

Both snippets should function the same, but the second example should be much faster. The first snippet continues to work as previously.

_side note: my git config (I think) has squashed extraneous whitespace - sorry_
