### PR TITLE
Change splunklib logging

### DIFF
--- a/splunklib/__init__.py
+++ b/splunklib/__init__.py
@@ -17,3 +17,15 @@
 __version_info__ = (1, 3, 0)
 __version__ = ".".join(map(str, __version_info__))
 
+
+# Silence this module's logs by default
+import logging
+
+try:  # python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/splunklib/__init__.py
+++ b/splunklib/__init__.py
@@ -17,15 +17,3 @@
 __version_info__ = (1, 3, 0)
 __version__ = ".".join(map(str, __version_info__))
 
-
-# Silence this module's logs by default
-import logging
-
-try:  # python 2.7+
-    from logging import NullHandler
-except ImportError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-logging.getLogger(__name__).addHandler(NullHandler())

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -55,13 +55,15 @@ DEFAULT_HOST = "localhost"
 DEFAULT_PORT = "8089"
 DEFAULT_SCHEME = "https"
 
+log = logging.getLogger(__name__)
+
 def _log_duration(f):
     @wraps(f)
     def new_f(*args, **kwargs):
         start_time = datetime.now()
         val = f(*args, **kwargs)
         end_time = datetime.now()
-        logging.debug("Operation took %s", end_time-start_time)
+        log.debug("Operation took %s", end_time-start_time)
         return val
     return new_f
 
@@ -523,7 +525,7 @@ class Context(object):
         """
         path = self.authority + self._abspath(path_segment, owner=owner,
                                               app=app, sharing=sharing)
-        logging.debug("DELETE request to %s (body: %s)", path, repr(query))
+        log.debug("DELETE request to %s (body: %s)", path, repr(query))
         response = self.http.delete(path, self._auth_headers, **query)
         return response
 
@@ -581,7 +583,7 @@ class Context(object):
         """
         path = self.authority + self._abspath(path_segment, owner=owner,
                                               app=app, sharing=sharing)
-        logging.debug("GET request to %s (body: %s)", path, repr(query))
+        log.debug("GET request to %s (body: %s)", path, repr(query))
         response = self.http.get(path, self._auth_headers, **query)
         return response
 
@@ -653,7 +655,7 @@ class Context(object):
             headers = []
 
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
-        logging.debug("POST request to %s (body: %s)", path, repr(query))
+        log.debug("POST request to %s (body: %s)", path, repr(query))
         all_headers = headers + self._auth_headers
         response = self.http.post(path, all_headers, **query)
         return response
@@ -721,7 +723,7 @@ class Context(object):
             + self._abspath(path_segment, owner=owner,
                             app=app, sharing=sharing)
         all_headers = headers + self._auth_headers
-        logging.debug("%s request to %s (headers: %s, body: %s)",
+        log.debug("%s request to %s (headers: %s, body: %s)",
                       method, path, str(all_headers), repr(body))
         response = self.http.request(path,
                                      {'method': method,

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -110,6 +110,8 @@ XNAME_CONTENT = XNAMEF_ATOM % "content"
 
 MATCH_ENTRY_CONTENT = "%s/%s/*" % (XNAME_ENTRY, XNAME_CONTENT)
 
+log = logging.getLogger(__name__)
+
 
 class IllegalOperationException(Exception):
     """Thrown when an operation is not possible on the Splunk instance that a
@@ -1387,7 +1389,7 @@ class ReadOnlyCollection(Endpoint):
             if pagesize is None or N < pagesize:
                 break
             offset += N
-            logging.debug("pagesize=%d, fetched=%d, offset=%d, N=%d, kwargs=%s", pagesize, fetched, offset, N, kwargs)
+            log.debug("pagesize=%d, fetched=%d, offset=%d, N=%d, kwargs=%s", pagesize, fetched, offset, N, kwargs)
 
     # kwargs: count, offset, search, sort_dir, sort_key, sort_mode
     def list(self, count=None, **kwargs):
@@ -2455,9 +2457,9 @@ class Inputs(Collection):
             kinds = self.kinds
         if len(kinds) == 1:
             kind = kinds[0]
-            logging.debug("Inputs.list taking short circuit branch for single kind.")
+            log.debug("Inputs.list taking short circuit branch for single kind.")
             path = self.kindpath(kind)
-            logging.debug("Path for inputs: %s", path)
+            log.debug("Path for inputs: %s", path)
             try:
                 path = UrlEncoded(path, skip_encode=True)
                 response = self.get(path, **kwargs)


### PR DESCRIPTION
I have made a couple changes to the debug logging found within the splunklib module.

Before the debug logging was going to the Python root logger, which causes recursion if I'm using the Splunk SDK to send Python debug level logs to Splunk. The splunklib module should log to its own module rather than the Python root logger. In addition I added a NullHandler to the splunklib module so its logs are, by default, not forwarded to the root logger.

If one needs to view the splunklib module's debug logs, they can do something like this:

    import logging
    splunklib_logger = logging.getLogger('splunklib')
    splunklib_logger.addHandler(logging.FileHandler('debug.log'))

Let me know if I missed anything here, and if something needs to be changed.
Thanks!