### PR TITLE
hyperlink and wording fix

### DIFF
--- a/examples/analytics/README.md
+++ b/examples/analytics/README.md
@@ -73,7 +73,7 @@ Similarly to `AnalyticsTracker`, the `output.py` file defines the "output" side
 of the Analytics service. If you want to extract the events you logged in using
 `AnalyticsTracker`, you'd use the `AnalyticsRetriever` class.
 
-Creating an `AnalyticsTracker` instance is identical to the `AnalyticsTracker`:
+Creating an `AnalyticsRetriever` instance is identical to the `AnalyticsTracker`:
 
 ```python
 from analytics.output import AnalyticsRetriever
@@ -138,7 +138,7 @@ you can see a graph of events over time, properties, etc.
 
 We make use of the excellent open source
 [flot](http://code.google.com/p/flot/) graphing library to render
-our Javascript graphs. We also use the [`bottle.py`](bottlepy.org)
+our Javascript graphs. We also use the [`bottle.py`](http://bottlepy.org)
 micro-web framework.
 
 ## Running the Sample


### PR DESCRIPTION
Changed AnalyticsTracker to AnalyticsRetriever, since that is what the topic was discussing.
Fixed the bottle.py hyperlink, since it was trying to link relative instead of the bottlepy.org webpage.