### PR TITLE
patch for broken regex in search

### DIFF
--- a/splunklib/searchcommands/search_command_internals.py
+++ b/splunklib/searchcommands/search_command_internals.py
@@ -367,7 +367,7 @@ class SearchCommandParser(object):
         # Captures a set of name/value pairs when used with re.finditer
         ([_a-zA-Z][_a-zA-Z0-9]+)       # name
         \s*=\s*                        # =
-        ([^\s"]+|"(?:[^"]+|""|\\")*")  # value
+        ([^\s"]+|"(?:""|\\"|[^"])*")  # value
         """, re.VERBOSE)
 
     #endregion


### PR DESCRIPTION
The current regex doesn't work when escaping double quotes with a backslash.

