### PR TITLE
fix for Splunk Support Case: 204977

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1231,7 +1231,10 @@ def handler(key_file=None, cert_file=None, timeout=None):
             if timeout is not None:
                 connection.sock.settimeout(timeout)
             response = connection.getresponse()
-        finally:
+        ### fix for Splunk Support Case: 204977
+        ### this removes the "finally" keyword, which automatically closed the connection, making
+        ### it impossible to use the reader object on line 763 above (because the connection had been closed here.
+        except:
             connection.close()
 
         return {


### PR DESCRIPTION
This is a fix for the support Case 204977 which I opened a while back:  Without this fix, whenever I tried to execute a oneshot query, I would get back the following exception (this pull request fixes this issue):

  File "/usr/local/lib/python2.7/dist-packages/splunklib/client.py", line 305, in connect
    return Service(**kwargs).login()
  File "/usr/local/lib/python2.7/dist-packages/splunklib/binding.py", line 764, in login
    session = XML(body).findtext("./sessionKey")
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1301, in XML
    return parser.close()
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1654, in close
    self._raiseerror(v)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1506, in _raiseerror
    raise err
