### PR TITLE
Fix Splunk Streaming Command dict_reader.py attempts to iterate over none

### DIFF
--- a/splunklib/searchcommands/splunk_csv/dict_reader.py
+++ b/splunklib/searchcommands/splunk_csv/dict_reader.py
@@ -31,7 +31,7 @@ class DictReader(csv.DictReader, object):
             try:
                 self._fieldnames = self.reader.next()
             except StopIteration:
-                pass
+                self._fieldnames = []
             self.line_num = self.reader.line_num
             self.__mv_fieldnames = []
             self.__fieldnames = []


### PR DESCRIPTION
Close #110

Fix provided by @David-Noble-at-work