### PR TITLE
Support for passing in Basic Auth tokens and resolve issue with HTTP/1.1 reverse proxies

### DIFF
--- a/examples/abc/a.py
+++ b/examples/abc/a.py
@@ -32,6 +32,7 @@ headers = {
     'Content-Length': str(len(body)),
     'Host': HOST,
     'User-Agent': "a.py/1.0",
+    'Connection': "close",
     'Accept': "*/*"
 }
 try:
@@ -50,6 +51,7 @@ headers = {
     'Content-Length': "0",
     'Host': HOST,
     'User-Agent': "a.py/1.0",
+    'Connection': "close",
     'Accept': "*/*",
     'Authorization': "Splunk %s" % sessionKey,
 }

--- a/examples/async/async.py
+++ b/examples/async/async.py
@@ -160,6 +160,7 @@ def request(url, message, **kwargs):
         "Content-Length": str(len(body)),
         "Host": host,
         "User-Agent": "http.py/1.0",
+        "Connection": "close",
         "Accept": "*/*",
     }
 

--- a/examples/twitted/input.py
+++ b/examples/twitted/input.py
@@ -54,6 +54,7 @@ class Twitter:
             'Authorization': token,
             'Host': "stream.twitter.com",
             'User-Agent': "twitted.py/0.1",
+            'Connection': "close",
             'Accept': "*/*",
         }
         connection = httplib.HTTPSConnection(TWITTER_STREAM_HOST)

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -511,7 +511,7 @@ class Context(object):
             return []
         else:
             # Ensure the token is properly formatted
-            if self.token.startswith('Splunk '):
+            if self.token.startswith('Splunk ') or self.token.startswith('Basic '):
                 token = self.token
             else:
                 token = 'Splunk %s' % self.token

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1325,6 +1325,7 @@ def handler(key_file=None, cert_file=None, timeout=None):
             "Content-Length": str(len(body)),
             "Host": host,
             "User-Agent": "splunk-sdk-python/1.4",
+            "Connection": "close",
             "Accept": "*/*",
         } # defaults
         for key, value in message["headers"]:


### PR DESCRIPTION
Forgive these two minor fixes being in the same PR.  I discovered the HTTP/1.1 proxy issue while working on testing my changes for Basic Auth.

**Support for passing in Basic Auth tokens**
This pull request modifies the way Splunk handles user-specified tokens.  Currently, tokens that don't start with 'Splunk' get this prefix automatically inserted.  This clobbers any Basic Auth tokens that the user has previously explicitly passed in:
```python
from splunklib.client import Service

service = Service(host="splunk.myhost.net", port=8089, scheme="https", version=6.3,
                  token="Basic dGVzdHVzZXI6dGVzdHBhc3M=")

service.indexes['test'].submit("My message!", host="localhost", sourcetype="text")
```

**Resolve issue with HTTP/1.1 reverse proxies**
The Splunk SDK uses the built-in Python library `httplib` for making HTTP connections.  This library does not support the use of HTTP/1.1 `Connection: keep-alive`.  When used in its default mode, the request header `Connection: close` is automatically added to ensure compatibility with servers isn't broken.  However the Splunk library passes in its own headers without a Connection declaration.  Normally this isn't a problem, as the splunkd server running on 8089 does not support `keep-alive` either and just assumes the behavior to be `close`.

However if using a reverse proxy in front of this service, major issues arise because the SDK is not conforming to the HTTP/1.1 header spec, [RFC2616 Section 14.10](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10):
> HTTP/1.1 applications that do not support persistent connections MUST include the "close" connection option in every message.

In my testing (nginx and Apache2), Splunk SDK would receive an empty response on all GET requests and fail.  With this change, all requests proceed as expected.