### PR TITLE
Make splunklin.binding.ResponseReader.readline function.

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1270,7 +1270,8 @@ class ResponseReader(io.RawIOBase):
         self._buffer = ''
         if size is not None:
             size -= len(r)
-        r = r + self._response.read(size)
+        if size != 0:
+            r = r + self._response.read(size)
         return r
 
     def readable(self):


### PR DESCRIPTION
I bumped into this trying to do:

```
>>> conn = client.connect(...)
>>> result = conn.jobs.export('search ...', output_mode='csv')
>>> result.readline()
'"'
```

The problem is the 1 byte peek followed by a one byte read here:

https://hg.python.org/cpython/file/v2.7.5/Modules/_io/iobase.c#l466

This results in an attempt to read 0 bytes from the HTTPResponse in result._response, which ends up hitting this code path:

https://hg.python.org/cpython/file/v2.7.5/Lib/httplib.py#l567

We ask for 0 bytes, and sure enough, we get 0 bytes, but httplib sees this as "no data left" and closes the connection.

I couldn't figure out how best to test this, or indeed, how to run the test suite in such a way that the existing tests on HEAD of master all passed before I started work. But, functional testing has shown this to work.
