### PR TITLE
Addition of basic auth support

### DIFF
--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -686,6 +686,29 @@ class TestNamespace(unittest.TestCase):
     def test_namespace_fails(self):
         self.assertRaises(ValueError, binding.namespace, sharing="gobble")
 
+class TestBasicAuthentication(BindingTestCase):
+    def test_user_provided_credentials(self):
+        opts = self.opts.kwargs.copy()
+        opts["basic"] = True
+        opts["username"] = "boris the mad baboon"
+        opts["password"] = "nothing real"
+
+        newContext = binding.Context(**opts)
+        response = newContext.get("/services")
+        self.assertEqual(response.status, 200)
+
+        socket = newContext.connect()
+        socket.write("POST %s HTTP/1.1\r\n" % \
+                         self.context._abspath("some/path/to/post/to"))
+        socket.write("Host: %s:%s\r\n" % \
+                         (self.context.host, self.context.port))
+        socket.write("Accept-Encoding: identity\r\n")
+        socket.write("Authorization: %s\r\n" % \
+                         self.context.token)
+        socket.write("X-Splunk-Input-Mode: Streaming\r\n")
+        socket.write("\r\n")
+        socket.close()
+
 class TestTokenAuthentication(BindingTestCase):
     def test_preexisting_token(self):
         token = self.context.token

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -698,11 +698,12 @@ class TestBasicAuthentication(unittest.TestCase):
         import splunklib.client as client
         service = client.Service(**opts)
 
-     if getattr(unittest.TestCase, 'assertIsNotNone', None) is None:
-         def assertIsNotNone(self, obj, msg=None):
-            if obj is None:
-                raise self.failureException, (msg or '%r is not None' % obj)
-     def test_basic_in_auth_headers(self):
+    if getattr(unittest.TestCase, 'assertIsNotNone', None) is None:
+        def assertIsNotNone(self, obj, msg=None):
+           if obj is None:
+               raise self.failureException, (msg or '%r is not None' % obj)
+
+    def test_basic_in_auth_headers(self):
         self.assertIsNotNone(self.context._auth_headers)
         self.assertNotEqual(self.context._auth_headers, [])
         self.assertEqual(len(self.context._auth_headers), 1)


### PR DESCRIPTION
Following the pattern defined in https://github.com/splunk/splunk-sdk-ruby/pull/43, I have implemented Basic Auth in this PR.

```
from splunklib.client import Service

service = Service(host="splunk.myhost.net", port=8089, scheme="https", version=6.3,
                  basic=True, username="steve", password="puppydoge")

service.indexes['test'].submit("My message!", host="localhost", sourcetype="text")
```