### PR TITLE
#134 Do not remove leading/trailing whitespace

### DIFF
--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -153,9 +153,6 @@ def load_value(element, nametable=None):
         text = element.text
         if text is None: 
             return None
-        text = text.strip()
-        if len(text) == 0: 
-            return None
         return text
 
     # Look for the special case of a single well-known structure

--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -150,10 +150,7 @@ def load_value(element, nametable=None):
 
     # No children, assume a simple text value
     if count == 0:
-        text = element.text
-        if text is None: 
-            return None
-        return text
+        return element.text
 
     # Look for the special case of a single well-known structure
     if count == 1:


### PR DESCRIPTION
Fix issue https://github.com/splunk/splunk-sdk-python/issues/134, stop stripping leading/trailing white spaces from property values and return them as they are because these white spaces are significant sometimes.
