### PR TITLE
Partially fixes broken py26 support #141

### DIFF
--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -763,7 +763,7 @@ class RecordWriterV2(RecordWriter):
     def _write_chunk(self, metadata, body):
 
         if metadata:
-            metadata = str(''.join(self._iterencode_json({n: v for n, v in metadata if v is not None}, 0)))
+            metadata = str(''.join(self._iterencode_json(dict((n, v) for n, v in metadata if v is not None), 0)))
             metadata_length = len(metadata)
         else:
             metadata_length = 0

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -572,8 +572,8 @@ class SearchCommand(object):
                 debug('Writing configuration settings')
 
                 ifile = self._prepare_protocol_v1(argv, ifile, ofile)
-                self._record_writer.write_record({
-                    n: ','.join(v) if isinstance(v, (list, tuple)) else v for n, v in self._configuration.iteritems()})
+                self._record_writer.write_record(dict(
+                    (n, ','.join(v)) if isinstance(v, (list, tuple)) else v for n, v in self._configuration.iteritems()))
                 self.finish()
 
             elif argv[1] == '__EXECUTE__':
@@ -884,7 +884,7 @@ class SearchCommand(object):
         except StopIteration:
             return
 
-        mv_fieldnames = {name: name[len('__mv_'):] for name in fieldnames if name.startswith('__mv_')}
+        mv_fieldnames = dict((name, name[len('__mv_'):]) for name in fieldnames if name.startswith('__mv_'))
 
         if len(mv_fieldnames) == 0:
             for values in reader:
@@ -926,7 +926,7 @@ class SearchCommand(object):
                 except StopIteration:
                     return
 
-                mv_fieldnames = {name: name[len('__mv_'):] for name in fieldnames if name.startswith('__mv_')}
+                mv_fieldnames = dict((name, name[len('__mv_'):]) for name in fieldnames if name.startswith('__mv_'))
 
                 if len(mv_fieldnames) == 0:
                     for values in reader:


### PR DESCRIPTION
This PR removes the dictionary comprehensions. shutil.make_archive is used as well (added in py27) which will need to be changed. There may be other changes required as well.