### PR TITLE
Python 2.6 compatibility 

### DIFF
--- a/examples/searchcommands_app/README.md
+++ b/examples/searchcommands_app/README.md
@@ -41,7 +41,7 @@ The app is tested on Splunk 5 and 6. Here is its manifest:
 [3] [Python Logging HOWTO](http://docs.python.org/2/howto/logging.html)  
 [4] [ConfigParser—Configuration file parser](http://docs.python.org/2/library/configparser.html)
 [5] [searchbnf.conf](http://docs.splunk.com/Documentation/Splunk/latest/admin/Searchbnfconf)
-[6] [Set permissions in the file system](http://goo.gl/1oDT7r)
+[6] [Set permissions in the file system](http://docs.splunk.com/Documentation/Splunk/latest/AdvancedDev/SetPermissions#Set_permissions_in_the_filesystem)
 
 ## Installation
 

--- a/examples/searchcommands_app/package/README/logging.conf.spec
+++ b/examples/searchcommands_app/package/README/logging.conf.spec
@@ -1,7 +1,7 @@
 #
 # The format of this file is described in this article at Python.org:
 #
-#     [Configuration file format](http://goo.gl/K6edZ8)
+#     [Configuration file format](https://docs.python.org/2/library/logging.config.html#configuration-file-format)
 #
 # This file must contain sections called [loggers], [handlers] and [formatters] which identify by name the entities of
 # each type which are defined in the file. For each such entity, there is a separate section which identifies how that
@@ -57,7 +57,7 @@ propagate = [0|1]
 
 [handlers]
     * Specifies a list of handler keys.
-    * See [logging.handlers](http://goo.gl/9aoOx)
+    * See [logging.handlers](https://docs.python.org/2/library/logging.handlers.html)
 
 keys = <comma-separated strings>
     * A comma-separated list of handlers keys. Each key must have a corresponding [handler_<string>] section in the
@@ -86,7 +86,7 @@ formatter = <string>
 
 [formatters]
     * Specifies a list of formatter keys.
-    * See [logging.formatters](http://goo.gl/z5CBR3)
+    * See [logging.formatters](https://docs.python.org/2/howto/logging.html#formatters)
 
 keys = <comma-separated strings>
     * A comma-separated list of formatter keys. Each key must have a corresponding [formatter_<string>] section in the
@@ -105,12 +105,12 @@ datefmt = <string>
     * The strftime-compatible date/time format string. If empty, the package substitutes ISO8601 format date/times.
     * An example ISO8601 date/time is datetime(2015, 2, 6, 15, 53, 36, 786309).isoformat() ==
     * '2015-02-06T15:53:36.786309'. For a complete list of formatting directives, see section [strftime() and strptime()
-    * Behavior](http://goo.gl/6zUAGv)
+    * Behavior](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior)
     * Defaults to empty.
 
 format = <string>
     * The overall format string. This string uses %(<dictionary key>)s styled string substitution; the possible keys are
-    * documented in [LogRecord](http://goo.gl/qW83Dg) attributes. The following format string will log the time in a
+    * documented in [LogRecord](https://docs.python.org/2/library/logging.html#logging.LogRecord) attributes. The following format string will log the time in a
     * human-readable format, the severity of the message, and the contents of the message, in that order:
     *    format = '%(asctime)s - %(levelname)s - %(message)s'
     * A value is required.

--- a/examples/searchcommands_app/package/default/logging.conf
+++ b/examples/searchcommands_app/package/default/logging.conf
@@ -1,7 +1,7 @@
 #
 # The format and semantics of this file are described in this article at Python.org:
 #
-#     [Configuration file format](http://goo.gl/K6edZ8)
+#     [Configuration file format](https://docs.python.org/2/library/logging.config.html#configuration-file-format)
 #
 [loggers]
 keys = root, splunklib, CountMatchesCommand, GenerateHelloCommand, GenerateTextCommand, SimulateCommand, SumCommand
@@ -47,7 +47,7 @@ handlers = app    ; Default: stderr
 propagate = 0     ; Default: 1
 
 [handlers]
-# See [logging.handlers](http://goo.gl/9aoOx)
+# See [logging.handlers](https://docs.python.org/2/library/logging.handlers.html)
 keys = app, splunklib, stderr
 
 [handler_app]

--- a/examples/searchcommands_app/setup.py
+++ b/examples/searchcommands_app/setup.py
@@ -57,7 +57,10 @@ if os.name == 'nt':
     patch_os()
     del locals()['patch_os']  # since this function has done its job
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except:
+    from splunklib.ordereddict import OrderedDict
 from glob import glob
 from itertools import chain
 from setuptools import setup, Command

--- a/examples/searchcommands_template/default/logging.conf
+++ b/examples/searchcommands_template/default/logging.conf
@@ -1,7 +1,7 @@
 #
 # The format of this file is described in this article at Python.org:
 #
-#     [Configuration file format](http://goo.gl/K6edZ8)
+#     [Configuration file format](https://docs.python.org/2/library/logging.config.html#configuration-file-format)
 #
 [loggers]
 keys = root, splunklib, %(command.title())Command

--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -38,9 +38,9 @@ except:
     import xml.etree.ElementTree as et
 
 try:
-    from collections import OrderedDict
-except:
-    from ordereddict import OrderedDict
+    from collections import OrderedDict  # must be python 2.7
+except ImportError:
+    from ordereddict import OrderedDict  # for python 2.6, pip install ordereddict
 
 try:
     from cStringIO import StringIO

--- a/splunklib/searchcommands/decorators.py
+++ b/splunklib/searchcommands/decorators.py
@@ -16,7 +16,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import OrderedDict  # must be python 2.7
+try:
+    from collections import OrderedDict  # must be python 2.7
+except ImportError:
+    from splunklib.ordereddict import OrderedDict
+
 from inspect import getmembers, isclass, isfunction
 from itertools import imap
 

--- a/splunklib/searchcommands/decorators.py
+++ b/splunklib/searchcommands/decorators.py
@@ -238,7 +238,7 @@ class Option(property):
     **Example:**
 
     Long form. Useful when you wish to manage the option value and its deleter/getter/setter side-effects yourself. You
-    must provide a getter and a setter. If your :code:`Option` requires `destruction <http://goo.gl/4VSm1c>`_ you must
+    must provide a getter and a setter. If your :code:`Option` requires `destruction <https://docs.python.org/2/reference/datamodel.html#object.__del__>`_ you must
     also provide a deleter. You must be prepared to accept a value of :const:`None` which indicates that your
     :code:`Option` is unset.
 

--- a/splunklib/searchcommands/environment.py
+++ b/splunklib/searchcommands/environment.py
@@ -61,7 +61,7 @@ def configure_logging(logger_name, filename=None):
     :returns: The named logger and the location of the logging configuration file loaded.
     :rtype: tuple
 
-    .. _ConfigParser format: http://goo.gl/K6edZ8
+    .. _ConfigParser format: https://docs.python.org/2/library/logging.config.html#configuration-file-format
 
     """
     if filename is None:

--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -16,7 +16,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import deque, namedtuple, OrderedDict
+from collections import deque, namedtuple
+try:
+    from collections import OrderedDict  # must be python 2.7
+except ImportError:
+    from splunklib.ordereddict import OrderedDict
 from cStringIO import StringIO
 from itertools import chain, imap
 from json import JSONDecoder, JSONEncoder
@@ -763,7 +767,7 @@ class RecordWriterV2(RecordWriter):
     def _write_chunk(self, metadata, body):
 
         if metadata:
-            metadata = str(''.join(self._iterencode_json({n: v for n, v in metadata if v is not None}, 0)))
+            metadata = str(''.join(self._iterencode_json(dict([(n, v) for n, v in metadata if v is not None]), 0)))
             metadata_length = len(metadata)
         else:
             metadata_length = 0

--- a/splunklib/searchcommands/reporting_command.py
+++ b/splunklib/searchcommands/reporting_command.py
@@ -255,7 +255,7 @@ class ReportingCommand(SearchCommand):
             f = vars(command)[b'map']   # Function backing the map method
 
             # EXPLANATION OF PREVIOUS STATEMENT: There is no way to add custom attributes to methods. See [Why does
-            # setattr fail on a method](http://goo.gl/aiOsqh) for a discussion of this issue.
+            # setattr fail on a method](http://stackoverflow.com/questions/7891277/why-does-setattr-fail-on-a-bound-method) for a discussion of this issue.
 
             try:
                 settings = f._settings

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -1034,7 +1034,7 @@ SearchMetric = namedtuple(b'SearchMetric', (b'elapsed_seconds', b'invocation_cou
 def dispatch(command_class, argv=sys.argv, input_file=sys.stdin, output_file=sys.stdout, module_name=None):
     """ Instantiates and executes a search command class
 
-    This function implements a `conditional script stanza <http://goo.gl/OFaox6>`_ based on the value of
+    This function implements a `conditional script stanza <https://docs.python.org/2/library/__main__.html>`_ based on the value of
     :code:`module_name`::
 
         if module_name is None or module_name == '__main__':

--- a/tests/searchcommands/apps/app_with_logging_configuration/default/alternative-logging.conf
+++ b/tests/searchcommands/apps/app_with_logging_configuration/default/alternative-logging.conf
@@ -1,7 +1,7 @@
 #
 # The format and semantics of this file are described in this article at Python.org:
 #
-#     [Configuration file format](http://goo.gl/K6edZ8)
+#     [Configuration file format](https://docs.python.org/2/library/logging.config.html#configuration-file-format)
 #
 [loggers]
 keys = root, splunklib, SearchCommand
@@ -23,7 +23,7 @@ handlers = app        ; Default: stderr
 propagate = 0         ; Default: 1
 
 [handlers]
-# See [logging.handlers](http://goo.gl/9aoOx)
+# See [logging.handlers](https://docs.python.org/2/library/logging.handlers.html)
 keys = app, splunklib, stderr
 
 [handler_app]

--- a/tests/searchcommands/apps/app_with_logging_configuration/default/logging.conf
+++ b/tests/searchcommands/apps/app_with_logging_configuration/default/logging.conf
@@ -1,7 +1,7 @@
 #
 # The format and semantics of this file are described in this article at Python.org:
 #
-#     [Configuration file format](http://goo.gl/K6edZ8)
+#     [Configuration file format](https://docs.python.org/2/library/logging.config.html#configuration-file-format)
 #
 [loggers]
 keys = root, splunklib, SearchCommand
@@ -23,7 +23,7 @@ handlers = app        ; Default: stderr
 propagate = 0         ; Default: 1
 
 [handlers]
-# See [logging.handlers](http://goo.gl/9aoOx)
+# See [logging.handlers](https://docs.python.org/2/library/logging.handlers.html)
 keys = app, splunklib, stderr
 
 [handler_app]

--- a/tests/searchcommands/apps/app_with_logging_configuration/logging.conf
+++ b/tests/searchcommands/apps/app_with_logging_configuration/logging.conf
@@ -1,7 +1,7 @@
 #
 # The format and semantics of this file are described in this article at Python.org:
 #
-#     [Configuration file format](http://goo.gl/K6edZ8)
+#     [Configuration file format](https://docs.python.org/2/library/logging.config.html#configuration-file-format)
 #
 [loggers]
 keys = root, splunklib, SearchCommand
@@ -23,7 +23,7 @@ handlers = app        ; Default: stderr
 propagate = 0         ; Default: 1
 
 [handlers]
-# See [logging.handlers](http://goo.gl/9aoOx)
+# See [logging.handlers](https://docs.python.org/2/library/logging.handlers.html)
 keys = app, splunklib, stderr
 
 [handler_app]

--- a/tests/searchcommands/test_builtin_options.py
+++ b/tests/searchcommands/test_builtin_options.py
@@ -18,7 +18,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from cStringIO import StringIO
-from unittest import main, TestCase
+try:
+    from unittest2 import main, TestCase
+except ImportError:
+    from unittest import main, TestCase
 
 import os
 import sys
@@ -28,7 +31,13 @@ from splunklib.searchcommands import environment
 from splunklib.searchcommands.decorators import Configuration
 from splunklib.searchcommands.search_command import SearchCommand
 
-from tests.searchcommands import package_directory, rebase_environment
+try:
+    from tests.searchcommands import rebase_environment, package_directory
+except:
+    # Skip on Python 2.6
+    def rebase_environment(ignore):
+        return
+    pass
 
 
 @Configuration()

--- a/tests/searchcommands/test_decorators.py
+++ b/tests/searchcommands/test_decorators.py
@@ -17,7 +17,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import main, TestCase
+try:
+    from unittest2 import main, TestCase
+except ImportError:
+    from unittest import main, TestCase
 import sys
 
 from splunklib.searchcommands import Configuration, Option, environment, validators
@@ -25,7 +28,11 @@ from splunklib.searchcommands.decorators import ConfigurationSetting
 from splunklib.searchcommands.internals import json_encode_string
 from splunklib.searchcommands.search_command import SearchCommand
 
-from tests.searchcommands import rebase_environment
+try:
+    from tests.searchcommands import rebase_environment
+except ImportError:
+    # Skip on Python 2.6
+    pass
 
 
 @Configuration()
@@ -227,7 +234,7 @@ class TestDecorators(TestCase):
              (True, False),
              (None, 'anything other than a bool')),
             ('required_fields',
-             (['field_1', 'field_2'], {'field_1', 'field_2'}, ('field_1', 'field_2')),
+             (['field_1', 'field_2'], set(['field_1', 'field_2']), ('field_1', 'field_2')),
              (None, 0xdead, {'foo': 1, 'bar': 2})),
             ('requires_preop',
              (True, False),


### PR DESCRIPTION
This addresses all obvious errors when using Python 2.6, the issues are primarily in `searchcommands`.

TODOs:

- [ ] Search commands tests don't pass trivially on Python 2.6 as they should (might fix this in a future release)

Closes #141 