### PR TITLE
Fix 'maxresultrows' extraction bug

### DIFF
--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -684,7 +684,7 @@ class SearchCommand(object):
         # Write search command configuration for consumption by splunkd
         # noinspection PyBroadException
         try:
-            self._record_writer = RecordWriterV2(ofile, getattr(self._metadata, 'maxresultrows', None))
+            self._record_writer = RecordWriterV2(ofile, getattr(self._metadata.searchinfo, 'maxresultrows', None))
             self.fieldnames = []
             self.options.reset()
 

--- a/tests/searchcommands/test_search_command.py
+++ b/tests/searchcommands/test_search_command.py
@@ -378,7 +378,9 @@ class TestSearchCommand(TestCase):
                         '"show_configuration={show_configuration}",'
                         '"required_option_1=value_1",'
                         '"required_option_2=value_2"'
-                    ']'
+                    '],'
+                    '"maxresultrows": 10,'
+                    '"command": "countmatches"'
                 '}}'
             '}}')
 
@@ -472,6 +474,8 @@ class TestSearchCommand(TestCase):
         self.assertEqual(command_metadata.searchinfo.splunk_version, '20150522')
         self.assertEqual(command_metadata.searchinfo.splunkd_uri, 'https://127.0.0.1:8089')
         self.assertEqual(command_metadata.searchinfo.username, 'admin')
+        self.assertEqual(command_metadata.searchinfo.maxresultrows, 10)
+        self.assertEqual(command_metadata.searchinfo.command, 'countmatches')
 
         command.search_results_info.search_metrics = command.search_results_info.search_metrics.__dict__
         command.search_results_info.optional_fields_json = command.search_results_info.optional_fields_json.__dict__


### PR DESCRIPTION
Get the value of maxresultrows from searchinfo object in metadata instead of metadata. The metadata object has no attribute named 'maxresultrows'.
