### PR TITLE
Identical entity names will cause an infinite loop

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -933,7 +933,10 @@ class Entity(Endpoint):
     def _load_atom_entry(self, response):
         elem = _load_atom(response, XNAME_ENTRY)
         if isinstance(elem, list):
-            raise AmbiguousReferenceException("Fetch from server returned multiple entries for name %s." % self.name)
+            apps = [ele.entry.content.get('eai:appName') for ele in elem]
+
+            raise AmbiguousReferenceException(
+                "Fetch from server returned multiple entries for name '%s' in apps %s." % (elem[0].entry.title, apps))
         else:
             return elem.entry
 


### PR DESCRIPTION
Identical entity names will cause an infinite loop "RuntimeError: maximum recursion depth exceeded". Give a clear message about which applications have this entity.
Trying to `self.name` in `Raise AmbiguousReferenceException` will result in a dead loop. 
```
splunklib\client.py", line 928, in _load_atom_entry
    raise AmbiguousReferenceException("Fetch from server returned multiple entries for name %s." % self.name)
  splunklib\client.py", line 1067, in name
    return self.state.title
  splunklib\client.py", line 1091, in state
    if self._state is None: self.refresh()
  splunklib\client.py", line 1011, in refresh
    self._state = self.read(self.get())
  splunklib\client.py", line 1071, in read
    results = self._load_state(response)
splunklib\client.py", line 934, in _load_state
    entry = self._load_atom_entry(response)
client.py", line 928, in _load_atom_entry
    raise AmbiguousReferenceException("Fetch from server returned multiple entries for name %s." % self.name)
client.py", line 1067, in name
    return self.state.title
.
.
```