### PR TITLE
"handlers" stanza missing in examples/searchcommands_template/default/logging.conf

### DIFF
--- a/examples/searchcommands_template/bin/stream.py
+++ b/examples/searchcommands_template/bin/stream.py
@@ -20,6 +20,7 @@ class %(command.title())Command(StreamingCommand):
     """
     def stream(self, events):
        # Put your event transformation code here
-       pass
+       for event in events:
+          yield event
 
 dispatch(%(command.title())Command, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/examples/searchcommands_template/default/logging.conf
+++ b/examples/searchcommands_template/default/logging.conf
@@ -22,6 +22,9 @@ level = NOTSET    ; Default: WARNING
 handlers = app    ; Default: stderr
 propagate = 0     ; Default: 1
 
+[handlers]
+keys = app, splunklib, stderr
+
 [handler_app]
 # Select this handler to log events to $SPLUNK_HOME/var/log/splunk/searchcommands_app.log
 class = logging.handlers.RotatingFileHandler


### PR DESCRIPTION
Please see diff.
