### PR TITLE
remove Inputs.kind check to reduce performance impact on each rest call

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -2430,15 +2430,12 @@ class Inputs(Collection):
         :return: The relative endpoint path.
         :rtype: ``string``
         """
-        if kind in self.kinds:
-            return UrlEncoded(kind, skip_encode=True)
-        # Special cases
-        elif kind == 'tcp':
+        if kind == 'tcp':
             return UrlEncoded('tcp/raw', skip_encode=True)
         elif kind == 'splunktcp':
             return UrlEncoded('tcp/cooked', skip_encode=True)
         else:
-            raise ValueError("No such kind on server: %s" % kind)
+            return UrlEncoded(kind, skip_encode=True)
 
     def list(self, *kinds, **kwargs):
         """Returns a list of inputs that are in the :class:`Inputs` collection.


### PR DESCRIPTION
Hi, we encountered seriously performance issue when using splunklib.Inputs object, we found the root cause is splunklib.Inputs object will check the `kind` for each rest call, during check process splunklib will trigger lots of additional rest calls if there are too many kinds of data inputs in Splunk.

For the detailed info please go to: https://confluence.splunk.com/display/PROD/ERD+Performance+and+Design+Deficiency+in+SplunkLib+Inputs