### PR TITLE
Fix Configuration(distributed=True) resulting in a command that is NOT distributed

### DIFF
--- a/splunklib/searchcommands/generating_command.py
+++ b/splunklib/searchcommands/generating_command.py
@@ -308,7 +308,7 @@ class GeneratingCommand(SearchCommand):
             version = self.command.protocol_version
             if version == 2:
                 iteritems = ifilter(lambda (name, value): name != 'distributed', iteritems)
-                if self.distributed and self.type == 'streaming':
+                if not self.distributed and self.type == 'streaming':
                     iteritems = imap(
                         lambda (name, value): (name, 'stateful') if name == 'type' else (name, value), iteritems)
             return iteritems

--- a/splunklib/searchcommands/streaming_command.py
+++ b/splunklib/searchcommands/streaming_command.py
@@ -180,7 +180,7 @@ class StreamingCommand(SearchCommand):
                     iteritems = ifilter(lambda (name, value): name != 'clear_required_fields', iteritems)
             else:
                 iteritems = ifilter(lambda (name, value): name != 'distributed', iteritems)
-                if self.distributed:
+                if not self.distributed:
                     iteritems = imap(
                         lambda (name, value): (name, 'stateful') if name == 'type' else (name, value), iteritems)
             return iteritems

--- a/tests/searchcommands/test_configuration_settings.py
+++ b/tests/searchcommands/test_configuration_settings.py
@@ -81,7 +81,7 @@ class TestConfigurationSettings(TestCase):
 
         self.assertIs(command.configuration.distributed, False)
         self.assertIs(command.configuration.generating, True)
-        self.assertEqual(command.configuration.type, 'streaming')
+        self.assertEqual(command.configuration.type, 'stateful')
 
         command.configuration.distributed = True
 
@@ -96,7 +96,7 @@ class TestConfigurationSettings(TestCase):
 
         self.assertEqual(
             [(name, value) for name, value in command.configuration.iteritems()],
-            [('generating', True), ('type', 'stateful')])
+            [('generating', True), ('type', 'streaming')])
 
         return
 


### PR DESCRIPTION
As per support Case #488821, DVPL-7118, DEVC-1

In a generating command using SCP2 (chunked = true), commands are unexpectedly distributed

#!/usr/bin/env python

import sys
import time
import socket

from splunklib.searchcommands import dispatch, GeneratingCommand, Configuration, Option, validators

@Configuration(
  distributed=False
)
class distfalse(GeneratingCommand):
    def generate(self):
      yield {'_time': time.time(), '_raw': 'This ran on ' + socket.gethostname()}
      self.flush()

dispatch(distfalse, sys.argv, sys.stdin, sys.stdout, __name__)