### PR TITLE
Bugfix/spl 142009

### DIFF
--- a/examples/searchcommands_app/package/default/searchbnf.conf
+++ b/examples/searchcommands_app/package/default/searchbnf.conf
@@ -36,7 +36,7 @@ comment1 = \
 example1 = \
     | generatetext text="Hello world! How the heck are you?" count=6 \
         | filter predicate="(long(_serial) & 1) == 0" map="_raw = _raw.replace('world', 'Splunk')"
-category = eventing
+category = events
 appears-in = 1.5
 maintainer = dnoble
 usage = public

--- a/splunklib/searchcommands/eventing_command.py
+++ b/splunklib/searchcommands/eventing_command.py
@@ -113,10 +113,10 @@ class EventingCommand(SearchCommand):
 
             ''')
 
-        type = ConfigurationSetting(readonly=True, value='eventing', doc='''
+        type = ConfigurationSetting(readonly=True, value='events', doc='''
             Command type
 
-            Fixed: :const:`'eventing'`.
+            Fixed: :const:`'events'`.
 
             Supported by: SCP 2
 

--- a/splunklib/searchcommands/generating_command.py
+++ b/splunklib/searchcommands/generating_command.py
@@ -56,7 +56,7 @@ class GeneratingCommand(SearchCommand):
     +==========+=====================================+============================================+
     | streams  | streaming=True[,local=[True|False]] | type='streaming'[,distributed=[true|false] |
     +----------+-------------------------------------+--------------------------------------------+
-    | events   | retainsevents=True, streaming=False | type='eventing'                            |
+    | events   | retainsevents=True, streaming=False | type='events'                              |
     +----------+-------------------------------------+--------------------------------------------+
     | reports  | streaming=False                     | type='reporting'                           |
     +----------+-------------------------------------+--------------------------------------------+
@@ -112,7 +112,7 @@ class GeneratingCommand(SearchCommand):
     |          | settings to your command class:                   | setting to your command class:                    |
     |          |                                                   |                                                   |
     |          | .. code-block:: python                            | .. code-block:: python                            |
-    |          |     @Configuration(                               |     @Configuration(type='eventing')               |
+    |          |     @Configuration(                               |     @Configuration(type='events')                 |
     |          |         retainsevents=True, streaming=False)      |     class SomeCommand(GeneratingCommand)          |
     |          |     class SomeCommand(GeneratingCommand)          |         ...                                       |
     |          |         ...                                       |                                                   |
@@ -127,7 +127,7 @@ class GeneratingCommand(SearchCommand):
     Configure your command class like this, if you wish to support both protocols:
 
     .. code-block:: python
-        @Configuration(type='eventing', retainsevents=True, streaming=False)
+        @Configuration(type='events', retainsevents=True, streaming=False)
         class SomeCommand(GeneratingCommand)
             ...
 
@@ -280,7 +280,7 @@ class GeneratingCommand(SearchCommand):
             ====================  ======================================================================================
             Value                 Description
             --------------------  --------------------------------------------------------------------------------------
-            :const:`'eventing'`   Runs as the first command in the Splunk events pipeline. Cannot be distributed.
+            :const:`'events'`     Runs as the first command in the Splunk events pipeline. Cannot be distributed.
             :const:`'reporting'`  Runs as the first command in the Splunk reports pipeline. Cannot be distributed.
             :const:`'streaming'`  Runs as the first command in the Splunk streams pipeline. May be distributed.
             ====================  ======================================================================================

--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -326,7 +326,7 @@ class ConfigurationSettingsType(type):
             supporting_protocols=[1, 2]),
         'type': specification(
             type=(bytes, unicode),
-            constraint=lambda value: value in ('eventing', 'reporting', 'streaming'),
+            constraint=lambda value: value in ('events', 'reporting', 'streaming'),
             supporting_protocols=[2])}
 
 

--- a/tests/searchcommands/test_configuration_settings.py
+++ b/tests/searchcommands/test_configuration_settings.py
@@ -155,7 +155,7 @@ class TestConfigurationSettings(TestCase):
         command.configuration.required_fields = ['field_1', 'field_2', 'field_3']
 
         try:
-            command.configuration.type = 'eventing'
+            command.configuration.type = 'events'
         except AttributeError:
             pass
         except Exception as error:

--- a/tests/searchcommands/test_decorators.py
+++ b/tests/searchcommands/test_decorators.py
@@ -253,7 +253,7 @@ class TestDecorators(TestCase):
              (None, 0xdead)),
             ('type',
              ('events', 'reporting', 'streaming', b'events', b'reporting', b'streaming'),
-             ('events', 0xdead))):
+             ('eventing', 0xdead))):
 
             for value in values:
 

--- a/tests/searchcommands/test_decorators.py
+++ b/tests/searchcommands/test_decorators.py
@@ -252,7 +252,7 @@ class TestDecorators(TestCase):
              ('some unicode string', b'some byte string'),
              (None, 0xdead)),
             ('type',
-             ('eventing', 'reporting', 'streaming', b'eventing', b'reporting', b'streaming'),
+             ('events', 'reporting', 'streaming', b'events', b'reporting', b'streaming'),
              ('events', 0xdead))):
 
             for value in values:


### PR DESCRIPTION
Changed the SDK for python to accept generating command type as 'events' instead of 'eventing', for consistency with splunk core.