### PR TITLE
Fix XML responses to not throw errors for unicode characters

### DIFF
--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -76,7 +76,7 @@ def load(text, match=None):
         'namespaces': [],
         'names': {}
     }
-    root = XML(text)
+    root = XML(text.encode('utf-8'))
     items = [root] if match is None else root.findall(match)
     count = len(items)
     if count == 0: 

--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -76,7 +76,11 @@ def load(text, match=None):
         'namespaces': [],
         'names': {}
     }
-    root = XML(text.encode('utf-8'))
+
+    if isinstance(text, unicode):
+        text = text.encode('utf-8')
+
+    root = XML(text)
     items = [root] if match is None else root.findall(match)
     count = len(items)
     if count == 0: 

--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -17,6 +17,7 @@ format, which is the format used by most of the REST API.
 """
 
 from __future__ import absolute_import
+import sys
 from xml.etree.ElementTree import XML
 from splunklib import six
 
@@ -77,8 +78,10 @@ def load(text, match=None):
         'names': {}
     }
 
-    if isinstance(text, unicode):
-        text = text.encode('utf-8')
+    # Convert to unicode encoding in only python 2 for xml parser
+    if sys.version_info < (3, 0, 0):
+        if isinstance(text, unicode):
+            text = text.encode('utf-8')
 
     root = XML(text)
     items = [root] if match is None else root.findall(match)

--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -79,9 +79,8 @@ def load(text, match=None):
     }
 
     # Convert to unicode encoding in only python 2 for xml parser
-    if sys.version_info < (3, 0, 0):
-        if isinstance(text, unicode):
-            text = text.encode('utf-8')
+    if(sys.version_info < (3, 0, 0) and isinstance(text, unicode)):
+        text = text.encode('utf-8')
 
     root = XML(text)
     items = [root] if match is None else root.findall(match)


### PR DESCRIPTION
Changed `splunklib/data.py` `load` function to convert text provided into a utf-8 string so that Python XML parser will not throw errors when processing utf-8 encoded responses.