### PR TITLE
Fix HTTP 400 errors for certain post requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,28 +282,16 @@ If you would like to contribute to the SDK, go here for more information:
 
 ### Support
 
-1. You will be granted support if you or your company are already covered 
-   under an existing maintenance/support agreement. Send an email to 
-   _support@splunk.com_ and include "Splunk SDK for Python" in the subject line. 
+Beginning September 2018, the Splunk SDKs for C#, Java, JavaScript, and Python will no longer be supported through Splunk Support.
 
-2. If you are not covered under an existing maintenance/support agreement, you 
-   can find help through the broader community at:
+You can still request assistance using the following options:
 
-   <ul>
-   <li><a href='http://splunk-base.splunk.com/answers/'>Splunk Answers</a> (use 
-    the <b>sdk</b>, <b>java</b>, <b>python</b>, and <b>javascript</b> tags to 
-    identify your questions)</li>
-   <li><a href='http://groups.google.com/group/splunkdev'>Splunkdev Google 
-    Group</a></li>
-   </ul>
-3. Splunk will NOT provide support for SDKs if the core library (the 
-   code in the <b>/splunklib</b> directory) has been modified. If you modify an 
-   SDK and want support, you can find help through the broader community and 
-   Splunk answers (see above). We would also like to know why you modified the 
-   core library&mdash;please send feedback to _devinfo@splunk.com_.
-4. File any issues on 
-   [GitHub](https://github.com/splunk/splunk-sdk-python/issues).
+* Post questions to [Splunk Answers](http://splunk-base.splunk.com/answers/). Be sure to use tags to identify the SDK or tool you are having an issue with.
 
+* File an issue on [GitHub](https://github.com/splunk/).
+
+* Send feedback to _devinfo@splunk.com_.
+ 
 ### Contact Us
 
 You can reach the Developer Platform team at _devinfo@splunk.com_.

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -671,7 +671,7 @@ class Context(object):
 
     @_authentication
     @_log_duration
-    def post(self, path_segment, owner=None, app=None, sharing=None, headers=None, **query):
+    def post(self, path_segment, headers=None, **query):
         """Performs a POST operation from the REST path segment with the given
         namespace and query.
 
@@ -681,7 +681,7 @@ class Context(object):
         the ``autologin`` field of :func:`connect` is set to ``True``.
 
         If *owner*, *app*, and *sharing* are omitted, this method uses the
-        default :class:`Context` namespace. All other keyword arguments are
+        default :class:`Context` namespace. All keyword arguments are
         included in the URL as query parameters.
 
         Some of Splunk's endpoints, such as ``receivers/simple`` and
@@ -697,12 +697,6 @@ class Context(object):
              *path_segment*.
         :param path_segment: A REST path segment.
         :type path_segment: ``string``
-        :param owner: The owner context of the namespace (optional).
-        :type owner: ``string``
-        :param app: The app context of the namespace (optional).
-        :type app: ``string``
-        :param sharing: The sharing mode of the namespace (optional).
-        :type sharing: ``string``
         :param headers: List of extra HTTP headers to send (optional).
         :type headers: ``list`` of 2-tuples.
         :param query: All other keyword arguments, which are used as query
@@ -733,8 +727,17 @@ class Context(object):
             c.post('saved/searches', name='boris',
                    search='search * earliest=-1m | head 1')
         """
+        owner = None
+        app = None
+        sharing = None
         if headers is None:
             headers = []
+        if 'owner' in query:
+            owner = query['owner']
+        if 'app' in query:
+            app = query['app']
+        if 'sharing' in query:
+            sharing = query['sharing']
 
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
         logging.debug("POST request to %s (body: %s)", path, repr(query))


### PR DESCRIPTION
This is one possible fix I came up with for issue #207. By moving owner, app, and sharing from arguments to kwargs in the post method, they will be included in the request body. This will fix any 400 errors that result from owner, app, or sharing being left out of REST requests that require them to be explicitly defined in the body of the request.