### PR TITLE
Add an await_completion method on Job just to simplify the common case

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -2887,6 +2887,38 @@ class Job(Entity):
         self.post("control", action="unpause")
         return self
 
+    def await_completion(self, sleep_interval, callback=lambda done, progress: False):
+        """Waits for the job to complete, checking every sleep_interval seconds.
+        If callback is provided, will call the callback for every poll interval
+        with an indication of completion and progress.  If the callback returns
+        true, then the method will return, giving control back to the caller.
+
+        Regardless of the return value of the callback, await_completion always 
+        returns control back to the caller once the job has completed.
+
+        :param `sleep_interval`: The number of seconds between each poll
+        :type value: ``integer``
+        :param `callback`: Optional. A function of two arguments, the first is a 
+        boolean representing if the job has completed.  The second is a floating 
+        point number representing how much of the job has completed.  Returns a 
+        boolean that, if True, causes the await_completion call to return, if 
+        False, polling will continue.
+        :type value: ``function``
+
+        :return: The :class:`Job`
+        """
+        while True:
+            while not job.is_ready():
+                pass
+            progress = float(self._state.content["doneProgress"])
+
+            isDone = self.is_done()
+
+            if callback(isDone, progress) or isDone:
+                return self
+
+            sleep(sleep_interval)
+
 
 class Jobs(Collection):
     """This class represents a collection of search jobs. Retrieve this

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -34,7 +34,7 @@ import splunklib.results as results
 
 from splunklib.binding import _log_duration, HTTPError
 
-# TODO: Determine if we should be importing ExpatError if ParseError is not avaialble (e.g., on Python 2.6)
+# TODO: Determine if we should be importing ExpatError if ParseError is not available (e.g., on Python 2.6)
 # There's code below that now catches SyntaxError instead of ParseError. Should we be catching ExpathError instead?
 
 # from xml.etree.ElementTree import ParseError


### PR DESCRIPTION
This PR creates an `await_completion" method on the Job class just to make the common case of "I submitted a search and now just want to wait until the results are ready, without copy-and-pasting a while loop around everywhere" more simple-like.

I tried to figure out how to add a test for it as well, but I think my general lack of familiarity with Python mixed with lack of familiarity with this code made it hard for me to figure out how to add the test.  As such, I haven't actually run this code yet, so there could be glaringly obvious problems and I apologize.  I decided to generate the PR to ask for help in creating the test.  

Can you provide any pointers for how I can test this?  I was basically looking for a test that was waiting on results, but didn't really find one...