### PR TITLE
Searchcommands: add full support for unicode

### DIFF
--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -22,7 +22,7 @@ try:
     from collections import OrderedDict  # must be python 2.7
 except ImportError:
     from ..ordereddict import OrderedDict
-from splunklib.six.moves import cStringIO as StringIO
+from splunklib.six.moves import StringIO
 from itertools import chain
 from splunklib.six.moves import map as imap
 from json import JSONDecoder, JSONEncoder

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     from ..ordereddict import OrderedDict
 from copy import deepcopy
-from splunklib.six.moves import cStringIO as StringIO
+from splunklib.six.moves import StringIO
 from itertools import chain, islice
 from splunklib.six.moves import filter as ifilter, map as imap, zip as izip
 from splunklib import six
@@ -850,7 +850,6 @@ class SearchCommand(object):
 
     @staticmethod
     def _read_chunk(ifile):
-
         # noinspection PyBroadException
         try:
             header = ifile.readline()

--- a/splunklib/searchcommands/validators.py
+++ b/splunklib/searchcommands/validators.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from json.encoder import encode_basestring_ascii as json_encode_string
 from collections import namedtuple
-from splunklib.six.moves import cStringIO as StringIO
+from splunklib.six.moves import StringIO
 from io import open
 import csv
 import os

--- a/tests/searchcommands/test_search_command.py
+++ b/tests/searchcommands/test_search_command.py
@@ -493,7 +493,7 @@ class TestSearchCommand(TestCase):
         self.assertEqual(command_metadata.searchinfo.latest_time, 0.0)
         self.assertEqual(command_metadata.searchinfo.owner, 'admin')
         self.assertEqual(command_metadata.searchinfo.raw_args, command_metadata.searchinfo.args)
-        self.assertEqual(command_metadata.searchinfo.search, '| inputlookup tweets | countmatches fieldname=word_count pattern="\\w+" text record=t | export add_timestamp=f add_offset=t format=csv segmentation=raw')
+        self.assertEqual(command_metadata.searchinfo.search, 'Ａ| inputlookup tweets | countmatches fieldname=word_count pattern="\\w+" text record=t | export add_timestamp=f add_offset=t format=csv segmentation=raw')
         self.assertEqual(command_metadata.searchinfo.session_key, '0JbG1fJEvXrL6iYZw9y7tmvd6nHjTKj7ggaE7a4Jv5R0UIbeYJ65kThn^3hiNeoqzMT_LOtLpVR3Y8TIJyr5bkHUElMijYZ8l14wU0L4n^Oa5QxepsZNUIIQCBm^')
         self.assertEqual(command_metadata.searchinfo.sid, '1433261372.158')
         self.assertEqual(command_metadata.searchinfo.splunk_version, '20150522')

--- a/tests/searchcommands/test_search_command.py
+++ b/tests/searchcommands/test_search_command.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 #
 # Copyright 2011-2015 Splunk, Inc.
 #
@@ -22,7 +23,7 @@ from splunklib.searchcommands.decorators import ConfigurationSetting, Option
 from splunklib.searchcommands.search_command import SearchCommand
 from splunklib.client import Service
 
-from splunklib.six.moves import cStringIO as StringIO
+from splunklib.six.moves import StringIO
 from splunklib.six.moves import zip as izip
 from json.encoder import encode_basestring as encode_string
 from unittest import main, TestCase
@@ -388,7 +389,7 @@ class TestSearchCommand(TestCase):
                         '"required_option_1=value_1",'
                         '"required_option_2=value_2"'
                     '],'
-                    '"search": "%7C%20inputlookup%20tweets%20%7C%20countmatches%20fieldname%3Dword_count%20pattern%3D%22%5Cw%2B%22%20text%20record%3Dt%20%7C%20export%20add_timestamp%3Df%20add_offset%3Dt%20format%3Dcsv%20segmentation%3Draw",'
+                    '"search": "Ａ%7C%20inputlookup%20tweets%20%7C%20countmatches%20fieldname%3Dword_count%20pattern%3D%22%5Cw%2B%22%20text%20record%3Dt%20%7C%20export%20add_timestamp%3Df%20add_offset%3Dt%20format%3Dcsv%20segmentation%3Draw",'
                     '"earliest_time": "0",'
                     '"session_key": "0JbG1fJEvXrL6iYZw9y7tmvd6nHjTKj7ggaE7a4Jv5R0UIbeYJ65kThn^3hiNeoqzMT_LOtLpVR3Y8TIJyr5bkHUElMijYZ8l14wU0L4n^Oa5QxepsZNUIIQCBm^",'
                     '"owner": "admin",'


### PR DESCRIPTION
We're now using `StringIO` instead of `cStringIO` (which doesn't have unicode support). For Python 2 there may be a performance tradeoff, but that's better than the search command exiting with a unicode exception!

Partially addresses #198, mainly the issue raised by @Cavalierski