### PR TITLE
Fix ssl verify to require certs when true

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1321,7 +1321,7 @@ class ResponseReader(io.RawIOBase):
         return bytes_read
 
 
-def handler(key_file=None, cert_file=None, timeout=None, verify=True):
+def handler(key_file=None, cert_file=None, timeout=None, verify=False):
     """This class returns an instance of the default HTTP request handler using
     the values you provide.
 


### PR DESCRIPTION
- Correct logic to always look for cert files when verify=True
- Pass key_file and cert_file to handler from HttpLib
- Changed default value of verify to False for backward compat