### PR TITLE
Possible fix for #207?

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -746,7 +746,7 @@ class Context(object):
         if headers is None:
             headers = []
 
-        query = { key.lstrip('__'): val for key, val in query.items() }
+        query = { key.lstrip('_dup__'): val for key, val in query.items() }
 
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
         logging.debug("POST request to %s (body: %s)", path, repr(query))

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -746,7 +746,7 @@ class Context(object):
         if headers is None:
             headers = []
 
-        query = { key.lstrip('_dup__'): val for key, val in query.items() }
+        query = { key.replace('_dup__', ''): val for key, val in query.items() }
 
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
         logging.debug("POST request to %s (body: %s)", path, repr(query))

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -746,6 +746,8 @@ class Context(object):
         if headers is None:
             headers = []
 
+        query = { key.lstrip('__'): val for key, val in query.items() }
+
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
         logging.debug("POST request to %s (body: %s)", path, repr(query))
         all_headers = headers + self.additional_headers + self._auth_headers

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1057,10 +1057,10 @@ class Entity(Endpoint):
             search = s.apps['search']
             search.access_update(**{'owner': 'new_owner', 'perms.read': 'admin, power', perms.write: '*'})
         """
-        kwargs = {'__' + key if key == 'owner' or key == 'app' or key == 'sharing' else key: val for key, val in kwargs.items()}
-        kwargs['__owner'] = kwargs.get('__owner', self.access.get('owner'))
-        kwargs['__app'] = kwargs.get('__app', self.access.get('app'))
-        kwargs['__sharing'] = kwargs.get('__sharing', self.access('sharing'))
+        kwargs = {'_dup__' + key if key == 'owner' or key == 'app' or key == 'sharing' else key: val for key, val in kwargs.items()}
+        kwargs['_dup__owner'] = kwargs.get('_dup__owner', self.access.get('owner'))
+        kwargs['_dup__app'] = kwargs.get('_dup__app', self.access.get('app'))
+        kwargs['_dup__sharing'] = kwargs.get('_dup__sharing', self.access('sharing'))
         self.service.post(self.path + 'acl', **kwargs)
         return self
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1060,7 +1060,7 @@ class Entity(Endpoint):
         kwargs = {'_dup__' + key if key == 'owner' or key == 'app' or key == 'sharing' else key: val for key, val in kwargs.items()}
         kwargs['_dup__owner'] = kwargs.get('_dup__owner', self.access.get('owner'))
         kwargs['_dup__app'] = kwargs.get('_dup__app', self.access.get('app'))
-        kwargs['_dup__sharing'] = kwargs.get('_dup__sharing', self.access('sharing'))
+        kwargs['_dup__sharing'] = kwargs.get('_dup__sharing', self.access.get('sharing'))
         self.service.post(self.path + 'acl', **kwargs)
         return self
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1040,6 +1040,29 @@ class Entity(Endpoint):
             ``owner``, ``app``, and ``sharing``.
         """
         return self.state.access
+    
+    def access_update(self, **kwargs):
+        """Updates the server with the ACL along arguments you specify.
+
+        :param kwargs: ACL specific arguments (optional).
+        :type kwargs: ``dict``
+
+        :return: The entity this method is called on.
+        :rtype: class:`Entity`
+
+        **Example**::
+
+            import splunklib.client as client
+            s = client.connect(...)
+            search = s.apps['search']
+            search.access_update(**{'owner': 'new_owner', 'perms.read': 'admin, power', perms.write: '*'})
+        """
+        kwargs = {'__' + key if key == 'owner' or key == 'app' or key == 'sharing' else key: val for key, val in kwargs.items()}
+        kwargs['__owner'] = kwargs.get('__owner', self.access.get('owner'))
+        kwargs['__app'] = kwargs.get('__app', self.access.get('app'))
+        kwargs['__sharing'] = kwargs.get('__sharing', self.access('sharing'))
+        self.service.post(self.path + 'acl', **kwargs)
+        return self
 
     @property
     def content(self):


### PR DESCRIPTION
Could anyone please check if this would be ok for fixing #207 ? 

Uses __ for service.post() on binding.py for arguments like app, owner, sharing needed for example for post requests to the /acl path for changing permissions and also adds an access_update() to client.py so that the client can transparently call an update in permissions without having to use the __ in the start of those arguments. 

At least I believe this approach won't cause a breaking change by changing the method signature as said by @tdhellmann on https://github.com/splunk/splunk-sdk-python/pull/208