### PR TITLE
Don't output close tags if you haven't written a start tag

### DIFF
--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -82,4 +82,5 @@ class EventWriter(object):
 
     def close(self):
         """Write the closing </stream> tag to make this XML well formed."""
-        self._out.write(b"</stream>")
+        if self.header_written:
+          self._out.write(b"</stream>")


### PR DESCRIPTION
In looking at Splunk I found lots of events with just `</stream>` as the text. Looking at the code, the event_write class will always output the closing tag even if it doesn't output a start tag or any event. So, I added a check to see if there was a start tag written. If so, put a valid close tag. Otherwise, do not