### PR TITLE
splunkd CEXC does not support sending and receiving partial chunks. S…

### DIFF
--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -623,9 +623,6 @@ class RecordWriter(object):
         self._writerow(values)
         self._record_count += 1
 
-        if self._record_count >= self._maxresultrows:
-            self.flush(partial=True)
-
     try:
         # noinspection PyUnresolvedReferences
         from _json import make_encoder


### PR DESCRIPTION
…ee https://github.com/splunk/splunk-sdk-python/issues/150

Fix limited to the default of maxchunksize=0 configured in commands.conf