### PR TITLE
properly add parameters to request based on the method of the request

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -821,20 +821,21 @@ class Context(object):
 
         if body:
             body = _encode(**body)
+
             if method == "GET":
                 path = path + UrlEncoded('?' + body, skip_encode=True)
-                response = self.http.request(path,
-                                     {'method': method,
-                                      'headers': all_headers})
+                message = {'method': method,
+                           'headers': all_headers}
             else:
-                response = self.http.request(path,
-                                     {'method': method,
-                                      'headers': all_headers,
-                                      'body': body})
+                message = {'method': method,
+                           'headers': all_headers,
+                           'body': body}
         else:
-            response = self.http.request(path,
-                                         {'method': method,
-                                          'headers': all_headers})
+            message = {'method': method,
+                       'headers': all_headers}
+
+        response = self.http.request(path, message)
+
         return response
 
     def login(self):


### PR DESCRIPTION
This PR resolves #261 related to improper handling of `body` parameters within the `Context.request` method. The method used (`GET` or `POST`) will determine if the body is encoded as part of the url or passed as body into the request.

GET method requests (with and without a body) were tested and worked as expected.