### PR TITLE
Compatibility between Python 2 and 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,15 +14,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from setuptools import setup, Command
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from contextlib import closing
-from subprocess import check_call, STDOUT
 
 import os
-import sys
 import shutil
+from subprocess import STDOUT, check_call
+import sys
+
 import tarfile
 
+from setuptools import Command, setup
 import splunklib
 
 failed = False
@@ -196,7 +201,7 @@ class DistCommand(Command):
 
         # Create searchcommands_app-<three-part-version-number>-private.tar.gz
         # but only if we are on 2.7 or later
-        if sys.version_info >= (2,7):
+        if sys.version_info >= (2, 7):
             setup_py = os.path.join('examples', 'searchcommands_app', 'setup.py')
 
             check_call(('python', setup_py, 'build', '--force'), stderr=STDOUT, stdout=sys.stdout)

--- a/splunklib/__init__.py
+++ b/splunklib/__init__.py
@@ -15,6 +15,8 @@
 """Python library for Splunk."""
 
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from splunklib.six.moves import map
 __version_info__ = (1, 6, 6)
 __version__ = ".".join(map(str, __version_info__))

--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -17,6 +17,8 @@ format, which is the format used by most of the REST API.
 """
 
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 import sys
 from xml.etree.ElementTree import XML
 from splunklib import six

--- a/splunklib/ordereddict.py
+++ b/splunklib/ordereddict.py
@@ -78,7 +78,7 @@ class OrderedDict(dict, DictMixin):
         if last:
             key = next(reversed(self))
         else:
-            key = next((self).next())
+            key = next(self)
         value = self.pop(key)
         return key, value
 

--- a/splunklib/ordereddict.py
+++ b/splunklib/ordereddict.py
@@ -20,8 +20,13 @@
 #     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #     OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 from UserDict import DictMixin
 
+from splunklib.six.moves import zip
 
 class OrderedDict(dict, DictMixin):
 
@@ -71,9 +76,9 @@ class OrderedDict(dict, DictMixin):
         if not self:
             raise KeyError('dictionary is empty')
         if last:
-            key = reversed(self).next()
+            key = next(reversed(self))
         else:
-            key = iter(self).next()
+            key = next((self).next())
         value = self.pop(key)
         return key, value
 
@@ -102,7 +107,7 @@ class OrderedDict(dict, DictMixin):
     def __repr__(self):
         if not self:
             return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, self.items())
+        return '%s(%r)' % (self.__class__.__name__, list(self.items()))
 
     def copy(self):
         return self.__class__(self)
@@ -118,7 +123,7 @@ class OrderedDict(dict, DictMixin):
         if isinstance(other, OrderedDict):
             if len(self) != len(other):
                 return False
-            for p, q in  zip(self.items(), other.items()):
+            for p, q in  zip(list(self.items()), list(other.items())):
                 if p != q:
                     return False
             return True


### PR DESCRIPTION
These are some minor updates for compatibility between Python2 and Python3. 

Example changes:
- import \_\_future__ modules
- it.next() -> next(it)
- list(items) 