### PR TITLE
Bearer token support (using Splunk Token presented in v7.3)

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -481,6 +481,7 @@ class Context(object):
         self.username = kwargs.get("username", "")
         self.password = kwargs.get("password", "")
         self.basic = kwargs.get("basic", False)
+        self.bearerToken = kwargs.get("splunkToken", "")
         self.autologin = kwargs.get("autologin", False)
         self.additional_headers = kwargs.get("headers", [])
 
@@ -520,6 +521,9 @@ class Context(object):
             return [("Cookie", _make_cookie_header(list(self.get_cookies().items())))]
         elif self.basic and (self.username and self.password):
             token = 'Basic %s' % b64encode(("%s:%s" % (self.username, self.password)).encode('utf-8')).decode('ascii')
+            return [("Authorization", token)]
+        elif self.bearerToken:
+            token = 'Bearer %s' % self.bearerToken
             return [("Authorization", token)]
         elif self.token is _NoAuthenticationToken:
             return []
@@ -863,6 +867,10 @@ class Context(object):
             # as credentials were passed in.
             return
 
+        if self.bearerToken:
+            # Bearer auth mode requested, so this method is a nop as long
+            # as authentication token was passed in.
+            return
         # Only try to get a token and updated cookie if username & password are specified
         try:
             response = self.http.post(


### PR DESCRIPTION
Added support to [Splunk Token](https://docs.splunk.com/Documentation/Splunk/7.3.1/Security/Setupauthenticationwithtokens) presented in version 7.3.