### PR TITLE
Remove version check on ssl verify toggle

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1357,8 +1357,7 @@ def handler(key_file=None, cert_file=None, timeout=None, verify=False):
             if key_file is not None: kwargs['key_file'] = key_file
             if cert_file is not None: kwargs['cert_file'] = cert_file
 
-            # If running Python 2.7.9+, disable SSL certificate validation
-            if (sys.version_info >= (2,7,9) and key_file is None and cert_file is None) and not verify:
+            if not verify:
                 kwargs['context'] = ssl._create_unverified_context()
             return six.moves.http_client.HTTPSConnection(host, port, **kwargs)
         raise ValueError("unsupported scheme: %s" % scheme)


### PR DESCRIPTION
This commit broke things: https://github.com/splunk/splunk-sdk-python/pull/233/commits/ab1d66ce8117ce8763fab1d666e96a92d061fd62#diff-9510d778d209375b033cdfc42fa0cc4bL1344-R1348

If you were running python less than 2.7.9, it made it impossible to disable SSL verification.

At this point, I don't see the reason to keep the check for version 2.7.9+. If SSL isn't working, verification can just be disabled.