### PR TITLE
Remove clear_password assertions for storage/passwords tests

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1844,7 +1844,7 @@ class StoragePasswords(Collection):
 
         entries = _load_atom_entries(response)
         state = _parse_atom_entry(entries[0])
-        storage_password = StoragePassword(self.service, self._entity_path(state), state=state, skip_refresh=True)
+        storage_password = StoragePassword(self.service, self._entity_path(state))
 
         return storage_password
 

--- a/tests/test_storage_passwords.py
+++ b/tests/test_storage_passwords.py
@@ -41,7 +41,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, realm + ":" + username + ":")
 
         p.delete()
@@ -58,7 +57,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(p.realm, realm)
         # Prepends one escaped slash
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "changeme")
         # Checks for 2 escaped slashes (Splunk encodes the single slash)
         self.assertEqual(p.name, "\\" + realm + ":\\" + username + ":")
 
@@ -76,7 +74,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(p.realm, realm)
         # Prepends one escaped slash
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "changeme")
         # Checks for 2 escaped slashes (Splunk encodes the single slash)
         self.assertEqual(p.name, realm + ":" + username + ":")
 
@@ -91,7 +88,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, None)
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, ":" + username + ":")
 
         p.delete()
@@ -107,7 +103,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, ":start" + realm)
         self.assertEqual(p.username, username + ":end")
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name,
                          "\\:start" + realm + ":" + username + "\\:end:")
 
@@ -121,7 +116,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, user)
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name,
                          prefix + "\\:r\\:e\\:a\\:l\\:m\\::\\:u\\:s\\:e\\:r\\::")
 
@@ -139,7 +133,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, ":start::!@#$%^&*()_+{}:|<>?" + realm)
         self.assertEqual(p.username, username + ":end!@#$%^&*()_+{}:|<>?")
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name,
                          "\\:start\\:\\:!@#$%^&*()_+{}\\:|<>?" + realm + ":" + username + "\\:end!@#$%^&*()_+{}\\:|<>?:")
 
@@ -171,17 +164,14 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, realm + ":" + username + ":")
 
         p.update(password="Splunkeroo!")
-        self.assertEqual(p.clear_password, "changeme")
 
         p.refresh()
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "Splunkeroo!")
         self.assertEqual(p.name, realm + ":" + username + ":")
 
         p.delete()
@@ -195,7 +185,6 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, "myrealm")
         self.assertEqual(p.username, username)
-        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, "myrealm:" + username + ":")
 
         self.storage_passwords.delete(username, "myrealm")

--- a/tests/test_storage_passwords.py
+++ b/tests/test_storage_passwords.py
@@ -41,6 +41,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, realm + ":" + username + ":")
 
         p.delete()
@@ -57,6 +58,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(p.realm, realm)
         # Prepends one escaped slash
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "changeme")
         # Checks for 2 escaped slashes (Splunk encodes the single slash)
         self.assertEqual(p.name, "\\" + realm + ":\\" + username + ":")
 
@@ -74,6 +76,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(p.realm, realm)
         # Prepends one escaped slash
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "changeme")
         # Checks for 2 escaped slashes (Splunk encodes the single slash)
         self.assertEqual(p.name, realm + ":" + username + ":")
 
@@ -88,6 +91,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, None)
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, ":" + username + ":")
 
         p.delete()
@@ -103,6 +107,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, ":start" + realm)
         self.assertEqual(p.username, username + ":end")
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name,
                          "\\:start" + realm + ":" + username + "\\:end:")
 
@@ -116,6 +121,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, user)
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name,
                          prefix + "\\:r\\:e\\:a\\:l\\:m\\::\\:u\\:s\\:e\\:r\\::")
 
@@ -133,6 +139,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, ":start::!@#$%^&*()_+{}:|<>?" + realm)
         self.assertEqual(p.username, username + ":end!@#$%^&*()_+{}:|<>?")
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name,
                          "\\:start\\:\\:!@#$%^&*()_+{}\\:|<>?" + realm + ":" + username + "\\:end!@#$%^&*()_+{}\\:|<>?:")
 
@@ -164,14 +171,17 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, realm + ":" + username + ":")
 
         p.update(password="Splunkeroo!")
+        self.assertEqual(p.clear_password, "changeme")
 
         p.refresh()
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, realm)
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "Splunkeroo!")
         self.assertEqual(p.name, realm + ":" + username + ":")
 
         p.delete()
@@ -185,6 +195,7 @@ class Tests(testlib.SDKTestCase):
         self.assertEqual(start_count + 1, len(self.storage_passwords))
         self.assertEqual(p.realm, "myrealm")
         self.assertEqual(p.username, username)
+        self.assertEqual(p.clear_password, "changeme")
         self.assertEqual(p.name, "myrealm:" + username + ":")
 
         self.storage_passwords.delete(username, "myrealm")


### PR DESCRIPTION
POST requests to the /storage/passwords endpoint should not return the clear_password back in plaintext. The POST response should mask the clear_password but the Python SDK tests specifically check for the created or updated password. I removed those assertion checks.