### PR TITLE
EventWriter is writing bytes on stdout which is not supported in pyth…

### DIFF
--- a/splunklib/modularinput/event.py
+++ b/splunklib/modularinput/event.py
@@ -104,5 +104,5 @@ class Event(object):
         if self.done:
             ET.SubElement(event, "done")
 
-        stream.write(ET.tostring(event))
+        stream.write(ET.tostring(event).decode())
         stream.flush()

--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -55,7 +55,7 @@ class EventWriter(object):
         """
 
         if not self.header_written:
-            self._out.write(b"<stream>")
+            self._out.write("<stream>")
             self.header_written = True
 
         event.write_to(self._out)
@@ -68,7 +68,7 @@ class EventWriter(object):
         :param message: ``string``, message to log.
         """
 
-        self._err.write(("%s %s\n" % (severity, message)).encode('utf-8'))
+        self._err.write("%s %s\n" % (severity, message))
         self._err.flush()
 
     def write_xml_document(self, document):
@@ -77,9 +77,12 @@ class EventWriter(object):
 
         :param document: An ``ElementTree`` object.
         """
-        self._out.write(ET.tostring(document))
+        try:
+            self._out.write(ET.tostring(document))
+        except:
+            self._out.write(ET.tostring(document, encoding="unicode"))
         self._out.flush()
 
     def close(self):
         """Write the closing </stream> tag to make this XML well formed."""
-        self._out.write(b"</stream>")
+        self._out.write("</stream>")


### PR DESCRIPTION
…on3 #274

Resolved bug #274 for event_writer.py and event.py for modular input 