### PR TITLE
Fix extra chunks being sent for large chunks

### DIFF
--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -750,6 +750,11 @@ class RecordWriterV2(RecordWriter):
         RecordWriter.flush(self, finished, partial)  # validates arguments and the state of this instance
         inspector = self._inspector
 
+        if partial:
+            # Don't flush partial chunks, since the SCP v2 protocol does not
+            # provide a way to send partial chunks yet.
+            return
+
         if self._flushed is False:
 
             self._total_record_count += self._record_count

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -398,7 +398,7 @@ class SearchCommand(object):
         :return: :const:`None`
 
         """
-        self._record_writer.flush(partial=True)
+        self._record_writer.flush(finished=False)
 
     def prepare(self):
         """ Prepare for execution.


### PR DESCRIPTION
Previously, when an external command used the SCPv2 (chunked=true)
protocol via splunklib and returned with 50,000 or more rows for
one chunk, it would send two replies intead of one. This caused
the external command to get out of sync, sending chunk replies
before reading the corresponding request.

Fixes #150