### PR TITLE
Modular Input Decorators

### DIFF
--- a/splunklib/modularinput/__init__.py
+++ b/splunklib/modularinput/__init__.py
@@ -4,6 +4,7 @@ the splunklib.modularinput package like so:
 from splunklib.modularinput import *
 """
 from .argument import Argument
+from .decorators import Configuration
 from .event import Event
 from .event_writer import EventWriter
 from .input_definition import InputDefinition

--- a/splunklib/modularinput/argument.py
+++ b/splunklib/modularinput/argument.py
@@ -48,7 +48,7 @@ class Argument(object):
     data_type_number = "NUMBER"
     data_type_string = "STRING"
 
-    def __init__(self, name, description=None, validation=None,
+    def __init__(self, name=None, description=None, validation=None,
                  data_type=data_type_string, required_on_edit=False, required_on_create=False, title=None):
         """
         :param name: ``string``, identifier for this argument in Splunk.

--- a/splunklib/modularinput/decorators.py
+++ b/splunklib/modularinput/decorators.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+#
+# Copyright © 2011-2015 Splunk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"): you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+from splunklib import six
+
+from .script import Script
+from .scheme import Scheme
+from .argument import Argument
+
+from inspect import getmembers
+
+class InputItems(object):
+    def __init__(self, scheme, inputs):
+        self._scheme = scheme
+        self._inputs = inputs
+
+    def __iter__(self):
+        for input_name, input_config in self._inputs.items():
+            input = InputItem(self._scheme, input_config)
+            yield [input_name, input]
+
+class InputItem(object):
+    def __init__(self, scheme, config):
+        for name, value in config.items():
+            for argument in scheme.arguments:
+                if argument.name == name:
+                    if argument.data_type == argument.data_type_boolean:
+                        value = value.lower() not in ['n', 'no', 'f', 'false', '0']
+                    elif argument.data_type == argument.data_type_number:
+                        # assume float, as it can later be cast to int without issue
+                        value = float(value)
+            setattr(self, name, value)
+
+class Configuration(object):
+    """ Defines the configuration settings for a modular input.
+    """
+    def __init__(self, o=None, **kwargs):
+        self._settings = kwargs
+
+    def __call__(self, o):
+        o.name = o.__name__
+        o._settings = self._settings
+
+        # called by Script.get_scheme (unless overridden)
+        def decorated_get_scheme(fn_self):
+            scheme = Scheme(fn_self.name)
+
+            for setting_name, setting_value in fn_self._settings.items():
+                setattr(scheme, setting_name, setting_value)
+
+            for argument in fn_self._arguments:
+                scheme.add_argument(argument)
+
+            return scheme
+
+        # called by Script.stream_events (unless overridden)
+        def decorated_stream_events(fn_self, inputs, ew):
+            input_items = InputItems(fn_self.get_scheme(), inputs.inputs)
+            fn_self.preflight(input_items, ew)
+            for input_name, input_config in input_items:
+                fn_self.process_input(input_name, input_config, ew)
+            fn_self.postflight(input_items, ew)
+               
+        setattr(o, 'decorated_get_scheme', decorated_get_scheme)
+        setattr(o, 'decorated_stream_events', decorated_stream_events)
+
+        is_configuration_setting = lambda attribute: isinstance(attribute, Argument)
+        definitions = getmembers(o, is_configuration_setting)
+
+        o._arguments = []
+        for name, argument in definitions:
+            if not argument.name:
+                argument.name = name
+            o._arguments.append(argument)
+
+        return o


### PR DESCRIPTION
In an attempt to have similar design patterns to how custom search commands are created, and also to make the definition of the scheme, member access to configuration values, automatic casting of configuration types, and convenient .spec file generation, I implemented a proof of concept for decorators for the Script class.
It mimics much of how the search command decorators are implemented, with changes where necessary.
The functionality isn't fully complete, and is lacking validation of decorator parameters, but before spending a lot more time polishing and making it complete I wanted to get feedback regarding the willingness of the SDK team to merge such a PR, and also to get early feedback regarding which pieces the team would want implemented differently.

The summary of what this PR accomplishes is shown in this code snippet:

```from __future__ import absolute_import
from splunklib.modularinput import Configuration, Script, Argument
import sys

@Configuration(use_single_instance=True)
class DevSDKScript(Script):
    a_string_argument = Argument(data_type=Argument.data_type_string, description="A String Argument")
    a_boolean_argument = Argument(data_type=Argument.data_type_boolean, description="A Boolean Argument")
    a_number_argument = Argument(data_type=Argument.data_type_number, description="A Number Argument")

    # for inputs that need to perform preliminary actions (preparation) with knowledge of the entire set of inputs
    def preflight(self, input_items, ew):
        for input_name, input_item in input_items:
            ew.log("INFO", "{0} preflight".format(input_name))

    # process_input is called once per configured input to be more convenient, not requiring the developer
    #  to implement the interation themselves
    # stream_events is still overrideable if the developer prefers the existing method
    def process_input(self, input_name, input_item, ew):
        ew.log("INFO", "{0} stream_event".format(input_name))
        ew.log("INFO", " a_string_argument: {0}".format(input_item.a_string_argument))
        ew.log("INFO", " a_boolean_argument: {0}".format(input_item.a_boolean_argument))
        ew.log("INFO", " a_number_argument: {0}".format(input_item.a_number_argument))

    # for inputs that need to perform post actions (cleanup) with knowledge of the entire set of inputs
    def postflight(self, input_items, ew):
        for input_name, input_item in input_items:
            ew.log("INFO", "{0} postflight".format(input_name))

if __name__ == "__main__":
    sys.exit(DevSDKScript().run(sys.argv))