### PR TITLE
Ensure event XML is a string before writing.

### DIFF
--- a/splunklib/modularinput/event.py
+++ b/splunklib/modularinput/event.py
@@ -13,6 +13,9 @@
 # under the License.
 
 from __future__ import absolute_import
+
+import sys
+
 try:
     import xml.etree.cElementTree as ET
 except ImportError as ie:
@@ -103,6 +106,10 @@ class Event(object):
 
         if self.done:
             ET.SubElement(event, "done")
+            
+        event_string = ET.tostring(event)
+        if sys.version[0] != "2" and type(event_string) is not str:
+            event_string = str(event_string, 'utf-8')
 
-        stream.write(ET.tostring(event))
+        stream.write(event_string)
         stream.flush()


### PR DESCRIPTION
Fixes following issue.  See stacktrace.

Traceback (most recent call last):
  File "/Applications/Splunk/etc/apps/TA-1password/bin/ta_1password/aob_py3/modinput_wrapper/base_modinput.py", line 128, in stream_events
    self.collect_events(ew)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/onepassword_event_logs.py", line 76, in collect_events
    input_module.collect_events(self, ew)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/input_module_onepassword_event_logs.py", line 216, in collect_events
    event_stream.stream_events(CACHE_FOLDER, stanza_name)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/input_module_onepassword_event_logs.py", line 175, in stream_events
    self._process_event(event, input_name)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/input_module_onepassword_event_logs.py", line 150, in _process_event
    SplunkWriter.write_event(splunk_event)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/onepassword_lib/splunk_writer.py", line 10, in write_event
    SplunkWriter.writer.write_event(event)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/ta_1password/aob_py3/solnlib/packages/splunklib/modularinput/event_writer.py", line 57, in write_event
    event.write_to(self._out)
  File "/Applications/Splunk/etc/apps/TA-1password/bin/ta_1password/aob_py3/splunklib/modularinput/event.py", line 107, in write_to
    stream.write(ET.tostring(event))
TypeError: write() argument must be str, not bytes