### PR TITLE
Fix #309, avoid catastrophic backtracking in searchcommands.internals

### DIFF
--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -232,7 +232,7 @@ class CommandLineParser(object):
 
     _escaped_character_re = re.compile(r'(\\.|""|[\\"])')
 
-    _fieldnames_re = re.compile(r"""("(?:\\.|""|[^"])+"|(?:\\.|[^\s"])+)""")
+    _fieldnames_re = re.compile(r"""("(?:\\.|""|[^"\\])+"|(?:\\.|[^\s"])+)""")
 
     _options_re = re.compile(r"""
         # Captures a set of name/value pairs when used with re.finditer


### PR DESCRIPTION
Adding `\\` to `[^"]` avoids overlap with `\\.` in the branch. Without this the regex can catastrophically backtrack between the two branches.