### PR TITLE
Rename and cleanup follow-up for chunk synchronization

### DIFF
--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -776,7 +776,6 @@ class SearchCommand(object):
         # noinspection PyBroadException
         try:
             debug('Executing under protocol_version=2')
-            #self._records = self._records_protocol_v2
             self._metadata.action = 'execute'
             self._execute(ifile, None)
         except SystemExit:
@@ -951,9 +950,12 @@ class SearchCommand(object):
 
     def _execute_chunk_v2(self, process, chunk):
             metadata, body = chunk
-            if len(body) > 0:
-                records = self._read_csv_records(StringIO(body))
-                self._record_writer.write_records(process(records))
+
+            if len(body) <= 0:
+                return
+
+            records = self._read_csv_records(StringIO(body))
+            self._record_writer.write_records(process(records))
 
 
     def _report_unexpected_error(self):

--- a/tests/searchcommands/test_internals_v2.py
+++ b/tests/searchcommands/test_internals_v2.py
@@ -229,8 +229,10 @@ class TestInternals(TestCase):
 
         self.assertEqual(writer._chunk_count, 0)
         self.assertEqual(writer._record_count, 31)
+        self.assertEqual(writer.pending_record_count, 31)
         self.assertGreater(writer._buffer.tell(), 0)
         self.assertEqual(writer._total_record_count, 0)
+        self.assertEqual(writer.committed_record_count, 0)
         self.assertListEqual(writer._fieldnames, fieldnames)
         self.assertListEqual(writer._inspector['messages'], messages)
 
@@ -242,16 +244,18 @@ class TestInternals(TestCase):
 
         self.assertEqual(writer._chunk_count, 1)
         self.assertEqual(writer._record_count, 0)
+        self.assertEqual(writer.pending_record_count, 0)
         self.assertEqual(writer._buffer.tell(), 0)
         self.assertEqual(writer._buffer.getvalue(), '')
         self.assertEqual(writer._total_record_count, 31)
+        self.assertEqual(writer.committed_record_count, 31)
 
         self.assertRaises(AssertionError, writer.flush, finished=True, partial=True)
         self.assertRaises(AssertionError, writer.flush, finished='non-boolean')
         self.assertRaises(AssertionError, writer.flush, partial='non-boolean')
         self.assertRaises(AssertionError, writer.flush)
 
-        # For SCPv2 we should follow the finish negotiation protocol.
+        # P2 [ ] TODO: For SCPv2 we should follow the finish negotiation protocol.
         # self.assertRaises(RuntimeError, writer.write_record, {})
 
         self.assertFalse(writer._ofile.closed)


### PR DESCRIPTION
Brief summary of changes:

- Cleaned up commented-out code
- Renamed `_record_count` to `pending_record_count` and `_total_record_count` to `committed_record_count`. The old properties are still callable but produce a deprecated warning. (If you were actually setting those values, you probably shouldn't have been doing that.)
- `RecordWriterV1` now updates `committed_record_count` before clearing records. Previously it was the other way around, which seems like it would always produce incorrect data.