### PR TITLE
client: use six.string_types instead of basestring

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -3591,7 +3591,7 @@ class KVStoreCollection(Entity):
         :return: Result of POST request
         """
         kwargs = {}
-        kwargs['index.' + name] = value if isinstance(value, basestring) else json.dumps(value)
+        kwargs['index.' + name] = value if isinstance(value, six.string_types) else json.dumps(value)
         return self.post(**kwargs)
 
     def update_field(self, name, value):


### PR DESCRIPTION
Which is gone on modern python.