### PR TITLE
Use module-specific logger in library code instead of root logger

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -49,6 +49,7 @@ try:
 except ImportError as e:
     from xml.parsers.expat import ExpatError as ParseError
 
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "AuthenticationError",
@@ -70,7 +71,7 @@ def _log_duration(f):
         start_time = datetime.now()
         val = f(*args, **kwargs)
         end_time = datetime.now()
-        logging.debug("Operation took %s", end_time-start_time)
+        logger.debug("Operation took %s", end_time-start_time)
         return val
     return new_f
 
@@ -618,7 +619,7 @@ class Context(object):
         """
         path = self.authority + self._abspath(path_segment, owner=owner,
                                               app=app, sharing=sharing)
-        logging.debug("DELETE request to %s (body: %s)", path, repr(query))
+        logger.debug("DELETE request to %s (body: %s)", path, repr(query))
         response = self.http.delete(path, self._auth_headers, **query)
         return response
 
@@ -681,7 +682,7 @@ class Context(object):
 
         path = self.authority + self._abspath(path_segment, owner=owner,
                                               app=app, sharing=sharing)
-        logging.debug("GET request to %s (body: %s)", path, repr(query))
+        logger.debug("GET request to %s (body: %s)", path, repr(query))
         all_headers = headers + self.additional_headers + self._auth_headers
         response = self.http.get(path, all_headers, **query)
         return response
@@ -754,7 +755,7 @@ class Context(object):
             headers = []
 
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
-        logging.debug("POST request to %s (body: %s)", path, repr(query))
+        logger.debug("POST request to %s (body: %s)", path, repr(query))
         all_headers = headers + self.additional_headers + self._auth_headers
         response = self.http.post(path, all_headers, **query)
         return response
@@ -822,7 +823,7 @@ class Context(object):
             + self._abspath(path_segment, owner=owner,
                             app=app, sharing=sharing)
         all_headers = headers + self.additional_headers + self._auth_headers
-        logging.debug("%s request to %s (headers: %s, body: %s)",
+        logger.debug("%s request to %s (headers: %s, body: %s)",
                       method, path, str(all_headers), repr(body))
         response = self.http.request(path,
                                      {'method': method,

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -75,6 +75,8 @@ from .binding import (AuthenticationError, Context, HTTPError, UrlEncoded,
                       namespace)
 from .data import record
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "connect",
     "NotSupportedError",
@@ -1444,7 +1446,7 @@ class ReadOnlyCollection(Endpoint):
             if pagesize is None or N < pagesize:
                 break
             offset += N
-            logging.debug("pagesize=%d, fetched=%d, offset=%d, N=%d, kwargs=%s", pagesize, fetched, offset, N, kwargs)
+            logger.debug("pagesize=%d, fetched=%d, offset=%d, N=%d, kwargs=%s", pagesize, fetched, offset, N, kwargs)
 
     # kwargs: count, offset, search, sort_dir, sort_key, sort_mode
     def list(self, count=None, **kwargs):
@@ -2517,9 +2519,9 @@ class Inputs(Collection):
             kinds = self.kinds
         if len(kinds) == 1:
             kind = kinds[0]
-            logging.debug("Inputs.list taking short circuit branch for single kind.")
+            logger.debug("Inputs.list taking short circuit branch for single kind.")
             path = self.kindpath(kind)
-            logging.debug("Path for inputs: %s", path)
+            logger.debug("Path for inputs: %s", path)
             try:
                 path = UrlEncoded(path, skip_encode=True)
                 response = self.get(path, **kwargs)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,8 @@
 from __future__ import absolute_import
 from tests import testlib
 import logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
 
 import splunklib.client as client
 
@@ -37,9 +39,9 @@ class TestApp(testlib.SDKTestCase):
             # than entities like indexes, this is okay.
             self.app_name = testlib.tmpname()
             self.app = self.service.apps.create(self.app_name)
-            logging.debug("Creating app %s", self.app_name)
+            logger.debug("Creating app %s", self.app_name)
         else:
-            logging.debug("App %s already exists. Skipping creation.", self.app_name)
+            logger.debug("App %s already exists. Skipping creation.", self.app_name)
         if self.service.restart_required:
             self.service.restart(120)
         return
@@ -94,6 +96,7 @@ class TestApp(testlib.SDKTestCase):
 
     def test_package(self):
         p = self.app.package()
+        logger.debug('package(name=%s, path=%s, url=%s)', p.name, p.path, p.url)
         self.assertEqual(p.name, self.app_name)
         self.assertTrue(p.path.endswith(self.app_name + '.spl'))
         self.assertTrue(p.url.endswith(self.app_name + '.spl'))

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps = pytest
 
 distdir = build
 commands =
-    {env:TOXBUILD:python -m pytest --junitxml=test-reports/junit-{envname}.xml --cov --cov-config=.coveragerc} {posargs}
+    {env:TOXBUILD:python -m pytest -s --junitxml=test-reports/junit-{envname}.xml --cov --cov-config=.coveragerc} {posargs}
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
This pull request is to comply with [Advanced Logging Tutorial](https://docs.python.org/3/howto/logging.html#logging-advanced-tutorial):

> A good convention to use when naming loggers is to use a module-level logger, in each module which uses logging, named as follows:
> ```python
> logger = logging.getLogger(__name__)
> ```

This pull request is also almost identical to #94 which I'm not sure why was closed.