### PR TITLE
WIP: Release Github Actions Test (Do not merge!)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
-  push:
-    branches:
-      - master
+  # push:
+  #   branches:
+  #     - master
   workflow_dispatch: {}
 
 jobs:
@@ -67,15 +67,15 @@ jobs:
         run: pip install twine
       - name: Build package
         run: python setup.py sdist
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-      # Test upload
-      # - name: Publish package to TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@master
+      # - name: Publish package to PyPI
+      #   uses: pypa/gh-action-pypi-publish@v1.3.1
       #   with:
       #     user: __token__
-      #     password: ${{ secrets.test_pypi_password }}
-      #     repository_url: https://test.pypi.org/legacy/
+      #     password: ${{ secrets.pypi_password }}
+      # Test upload
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/splunklib/__init__.py
+++ b/splunklib/__init__.py
@@ -16,5 +16,5 @@
 
 from __future__ import absolute_import
 from splunklib.six.moves import map
-__version_info__ = (1, 6, 13)
+__version_info__ = (20, 6, 13)
 __version__ = ".".join(map(str, __version_info__))


### PR DESCRIPTION
This branch tests Github Actions in `master`. (You can only follow these steps if you're an admin of this repo.)

## Test Steps

- Go to https://github.com/splunk/splunk-sdk-python/actions?query=workflow%3ARelease and `Run Workflow` against this branch.
- Notice that after awhile, the following occur.
  - This branch is tagged with 20.6.13
  - Release 20.6.13 is created
  - Version 20.6.13 appears on Test PyPI: https://test.pypi.org/project/splunk-sdk/#files

You must upversion if you want to repeat these steps. Choose an obviously incorrect version.

## Cleanup

1. Delete the tag: `git push origin :20.6.13`
2. Go to https://github.com/splunk/splunk-sdk-python/releases and **Edit** the draft 20.6.13 release and discard it.
3. Close this pull request. Do not merge it.