### PR TITLE
Correct PendingDeprecationWarning

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -150,7 +150,7 @@ class ExamplesTestCase(testlib.SDKTestCase):
         result = run(
             "handlers/handlers_certs.py --ca_file=handlers/cacert.bad.pem",
             stderr=PIPE)
-        self.assertNotEquals(result, 0)
+        self.assertNotEqual(result, 0)
 
         # The proxy handler example requires that there be a proxy available
         # to relay requests, so we spin up a local proxy using the proxy
@@ -171,7 +171,7 @@ class ExamplesTestCase(testlib.SDKTestCase):
         # Run it again without the proxy and it should fail.
         result = run(
             "handlers/handler_proxy.py --proxy=localhost:80801", stderr=PIPE)
-        self.assertNotEquals(result, 0)
+        self.assertNotEqual(result, 0)
 
     def test_index(self):
         self.check_commands(


### PR DESCRIPTION
https://travis-ci.org/github/splunk/splunk-sdk-python/jobs/737207505

```
tests/test_examples.py::ExamplesTestCase::test_handlers
  /home/travis/build/splunk/splunk-sdk-python/tests/test_examples.py:153: PendingDeprecationWarning: Please use assertNotEqual instead.
    self.assertNotEquals(result, 0)
tests/test_examples.py::ExamplesTestCase::test_handlers
  /home/travis/build/splunk/splunk-sdk-python/tests/test_examples.py:174: PendingDeprecationWarning: Please use assertNotEqual instead.
    self.assertNotEquals(result, 0)
```