### PR TITLE
#380 PullRequest to enable supplying custom SSLContext Objects.

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -471,7 +471,7 @@ class Context(object):
     """
     def __init__(self, handler=None, **kwargs):
         self.http = HttpLib(handler, kwargs.get("verify", False), key_file=kwargs.get("key_file"),
-                            cert_file=kwargs.get("cert_file"))  # Default to False for backward compat
+                            cert_file=kwargs.get("cert_file"), context=kwargs.get("context"))  # Default to False for backward compat
         self.token = kwargs.get("token", _NoAuthenticationToken)
         if self.token is None: # In case someone explicitly passes token=None
             self.token = _NoAuthenticationToken
@@ -1137,9 +1137,9 @@ class HttpLib(object):
 
     If using the default handler, SSL verification can be disabled by passing verify=False.
     """
-    def __init__(self, custom_handler=None, verify=False, key_file=None, cert_file=None):
+    def __init__(self, custom_handler=None, verify=False, key_file=None, cert_file=None, context=None):
         if custom_handler is None:
-            self.handler = handler(verify=verify, key_file=key_file, cert_file=cert_file)
+            self.handler = handler(verify=verify, key_file=key_file, cert_file=cert_file, context=context)
         else:
             self.handler = custom_handler
         self._cookies = {}
@@ -1351,7 +1351,7 @@ class ResponseReader(io.RawIOBase):
         return bytes_read
 
 
-def handler(key_file=None, cert_file=None, timeout=None, verify=False):
+def handler(key_file=None, cert_file=None, timeout=None, verify=False, context=None):
     """This class returns an instance of the default HTTP request handler using
     the values you provide.
 
@@ -1363,6 +1363,8 @@ def handler(key_file=None, cert_file=None, timeout=None, verify=False):
     :type timeout: ``integer`` or "None"
     :param `verify`: Set to False to disable SSL verification on https connections.
     :type verify: ``Boolean``
+    :param `context`: The SSLContext that can is used with the HTTPSConnection when verify=True is enabled and context is specified
+    :type context: ``SSLContext`
     """
 
     def connect(scheme, host, port):
@@ -1376,6 +1378,10 @@ def handler(key_file=None, cert_file=None, timeout=None, verify=False):
 
             if not verify:
                 kwargs['context'] = ssl._create_unverified_context()
+            elif context:
+                # verify is True in elif branch and context is not None
+                kwargs['context'] = context
+
             return six.moves.http_client.HTTPSConnection(host, port, **kwargs)
         raise ValueError("unsupported scheme: %s" % scheme)
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -318,6 +318,8 @@ def connect(**kwargs):
     :type username: ``string``
     :param `password`: The password for the Splunk account.
     :type password: ``string``
+    :param `context`: The SSLContext that can be used when setting verify=True (optional)
+    :type context: ``SSLContext``
     :return: An initialized :class:`Service` connection.
 
     **Example**::


### PR DESCRIPTION
#380 PullRequest to enable supplying custom SSLContext Objects. This enables providing custom ca root certificates as well as other options such as TLS Versions and so on. 