### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/analytics/bottle.py
+++ b/examples/analytics/bottle.py
@@ -407,7 +407,7 @@ class Bottle(object):
 
         self.mounts = {}
         self.error_handler = {}
-        #: If true, most exceptions are catched and returned as :exc:`HTTPError`
+        #: If true, most exceptions are caught and returned as :exc:`HTTPError`
         self.catchall = catchall
         self.config = config or {}
         self.serve = True
@@ -638,8 +638,8 @@ class Bottle(object):
 
     def handle(self, path, method='GET'):
         """ (deprecated) Execute the first matching route callback and return
-            the result. :exc:`HTTPResponse` exceptions are catched and returned.
-            If :attr:`Bottle.catchall` is true, other exceptions are catched as
+            the result. :exc:`HTTPResponse` exceptions are caught and returned.
+            If :attr:`Bottle.catchall` is true, other exceptions are caught as
             well and returned as :exc:`HTTPError` instances (500).
         """
         depr("This method will change semantics in 0.10. Try to avoid it.")
@@ -1081,7 +1081,7 @@ class Response(threading.local):
             :param value: the value of the cookie.
             :param secret: required for signed cookies. (default: None)
             :param max_age: maximum age in seconds. (default: None)
-            :param expires: a datetime object or UNIX timestamp. (defaut: None)
+            :param expires: a datetime object or UNIX timestamp. (default: None)
             :param domain: the domain that is allowed to read the cookie.
               (default: current domain)
             :param path: limits the cookie to a given path (default: /)

--- a/examples/analytics/js/jquery.flot.selection.js
+++ b/examples/analytics/js/jquery.flot.selection.js
@@ -34,7 +34,7 @@ you want to know what's happening while it's happening,
 A "plotunselected" event with no arguments is emitted when the user
 clicks the mouse to remove the selection.
 
-The plugin allso adds the following methods to the plot object:
+The plugin also adds the following methods to the plot object:
 
 - setSelection(ranges, preventEvent)
 

--- a/examples/async/async.py
+++ b/examples/async/async.py
@@ -98,7 +98,7 @@ def main(argv):
         return results
 
     # We specify many queries to get show the advantages
-    # of paralleism.
+    # of parallelism.
     queries = [
         'search * | head 100',
         'search * | head 100',

--- a/examples/handlers/tiny-proxy.py
+++ b/examples/handlers/tiny-proxy.py
@@ -282,7 +282,7 @@ def daemonize(logger, opts):
         sys.exit(0)
     else:
         if os.fork () != 0:
-            ## allow the child pid to instanciate the server
+            ## allow the child pid to instantiate the server
             ## class
             time.sleep (1)
             sys.exit (0)

--- a/examples/job.py
+++ b/examples/job.py
@@ -18,7 +18,7 @@
 
 # All job commands operate on search 'specifiers' (spec). A search specifier
 # is either a search-id (sid) or the index of the search job in the list of
-# jobs, eg: @0 would specify the frist job in the list, @1 the second, and so
+# jobs, eg: @0 would specify the first job in the list, @1 the second, and so
 # on.
 
 from __future__ import absolute_import

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1070,7 +1070,7 @@ class AuthenticationError(HTTPError):
 #
 
 # Encode the given kwargs as a query string. This wrapper will also _encode
-# a list value as a sequence of assignemnts to the corresponding arg name,
+# a list value as a sequence of assignments to the corresponding arg name,
 # for example an argument such as 'foo=[1,2,3]' will be encoded as
 # 'foo=1&foo=2&foo=3'.
 def _encode(**kwargs):

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -856,7 +856,7 @@ class Entity(Endpoint):
         ent.whitelist
 
     However, because some of the field names are not valid Python identifiers,
-    the dictionary-like syntax is preferrable.
+    the dictionary-like syntax is preferable.
 
     The state of an :class:`Entity` object is cached, so accessing a field
     does not contact the server. If you think the values on the

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -36,7 +36,7 @@ from splunklib.binding import _log_duration, HTTPError
 
 import pytest
 
-# TODO: Determine if we should be importing ExpatError if ParseError is not avaialble (e.g., on Python 2.6)
+# TODO: Determine if we should be importing ExpatError if ParseError is not available (e.g., on Python 2.6)
 # There's code below that now catches SyntaxError instead of ParseError. Should we be catching ExpathError instead?
 
 # from xml.etree.ElementTree import ParseError


### PR DESCRIPTION
There are small typos in:
- examples/analytics/bottle.py
- examples/analytics/js/jquery.flot.selection.js
- examples/async/async.py
- examples/handlers/tiny-proxy.py
- examples/job.py
- splunklib/binding.py
- splunklib/client.py
- tests/test_job.py

Fixes:
- Should read `caught` rather than `catched`.
- Should read `preferable` rather than `preferrable`.
- Should read `parallelism` rather than `paralleism`.
- Should read `instantiate` rather than `instanciate`.
- Should read `first` rather than `frist`.
- Should read `default` rather than `defaut`.
- Should read `available` rather than `avaialble`.
- Should read `assignments` rather than `assignemnts`.
- Should read `also` rather than `allso`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md