### PR TITLE
Break out search argument to option parsing for v2 custom search commands

### DIFF
--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -634,6 +634,19 @@ class SearchCommand(object):
 
         debug('%s.process finished under protocol_version=1', class_name)
 
+    def _protocol_v2_option_parser(self, arg):
+        """ Determines if an argument is an Option/Value pair, or just a Positional Argument.
+            Method so different search commands can handle parsing of arguments differently.
+
+            :param arg: A single argument provided to the command from SPL
+            :type arg: str
+
+            :return: [OptionName, OptionValue] OR [PositionalArgument]
+            :rtype: List[str]
+
+        """
+        return arg.split('=', 1)
+
     def _process_protocol_v2(self, argv, ifile, ofile):
         """ Processes records on the `input stream optionally writing records to the output stream.
 
@@ -704,7 +717,7 @@ class SearchCommand(object):
 
             if args and type(args) == list:
                 for arg in args:
-                    result = arg.split('=', 1)
+                    result = self._protocol_v2_option_parser(arg)
                     if len(result) == 1:
                         self.fieldnames.append(str(result[0]))
                     else:


### PR DESCRIPTION
So I was wanting to write a custom search command, but for reasons of making things similar to existing commands, and because what I'm needing to take as positional parameters could have equals signs in them, I wanted to parse options that look like `--optionName=optionValue` instead of `optionName=optionValue`

Digging through the SDK I think I found the point where we were doing this, and wrapped it in a method so that I could override this parsing, but keep everything else passive for others who are already using the SDK.

I could see a future extension point where this entire parsing out options might be able to be overridden/modified, but I didn't have a need for that much customization yet.
