### PR TITLE
chore: remove unused imports

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -30,7 +30,6 @@ import io
 import logging
 import socket
 import ssl
-import sys
 from base64 import b64encode
 from contextlib import contextmanager
 from datetime import datetime
@@ -39,7 +38,6 @@ from io import BytesIO
 from xml.etree.ElementTree import XML
 
 from splunklib import six
-from splunklib.six import StringIO
 from splunklib.six.moves import urllib
 
 from .data import record

--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 import sys
 
-from io import TextIOWrapper, TextIOBase
 from splunklib.six import ensure_str
 from .event import ET
 


### PR DESCRIPTION
This PR removes unused imports from splunklib folder.