### PR TITLE
Removed strip() method in load_value() method from data.py file

### DIFF
--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -161,8 +161,8 @@ def load_value(element, nametable=None):
         text = element.text
         if text is None: 
             return None
-        text = text.strip()
-        if len(text) == 0: 
+
+        if len(text.strip()) == 0:
             return None
         return text
 

--- a/tests/test_storage_passwords.py
+++ b/tests/test_storage_passwords.py
@@ -222,6 +222,16 @@ class Tests(testlib.SDKTestCase):
         self.storage_passwords.delete(username + "/foo", "/myrealm")
         self.assertEqual(start_count, len(self.storage_passwords))
 
+    def test_spaces_in_username(self):
+        start_count = len(self.storage_passwords)
+        realm = testlib.tmpname()
+        username = "  user1  "
+
+        p = self.storage_passwords.create("changeme", username, realm)
+        self.assertEqual(p.username, username)
+
+        p.delete()
+        self.assertEqual(start_count, len(self.storage_passwords))
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
- removed strip() method in load_value() method, so now response value contain leading and trailing spaces while printing data in console. Change with reference to issue #400 