### PR TITLE
Hec endpoint issue

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -724,7 +724,7 @@ class Endpoint(object):
     """
     def __init__(self, service, path):
         self.service = service
-        self.path = path #if path.endswith('/') else path + '/'
+        self.path = path
 
     def get(self, path_segment="", owner=None, app=None, sharing=None, **query):
         """Performs a GET operation on the path segment relative to this endpoint.

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -724,7 +724,7 @@ class Endpoint(object):
     """
     def __init__(self, service, path):
         self.service = service
-        self.path = path if path.endswith('/') else path + '/'
+        self.path = path #if path.endswith('/') else path + '/'
 
     def get(self, path_segment="", owner=None, app=None, sharing=None, **query):
         """Performs a GET operation on the path segment relative to this endpoint.
@@ -782,6 +782,8 @@ class Endpoint(object):
         if path_segment.startswith('/'):
             path = path_segment
         else:
+            if not self.path.endswith('/'):
+                self.path = self.path if self.path != "" and path_segment.startswith('/') else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner,
                                          app=app, sharing=sharing)
         # ^-- This was "%s%s" % (self.path, path_segment).
@@ -842,6 +844,8 @@ class Endpoint(object):
         if path_segment.startswith('/'):
             path = path_segment
         else:
+            if not self.path.endswith('/'):
+                self.path = self.path if self.path != "" and path_segment.startswith('/') else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner, app=app, sharing=sharing)
         return self.service.post(path, owner=owner, app=app, sharing=sharing, **query)
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -847,7 +847,6 @@ class Endpoint(object):
             if not self.path.endswith('/') and path_segment != "":
                 self.path = self.path if path_segment.startswith('/') else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner, app=app, sharing=sharing)
-        print(path)
         return self.service.post(path, owner=owner, app=app, sharing=sharing, **query)
 
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -783,7 +783,7 @@ class Endpoint(object):
             path = path_segment
         else:
             if not self.path.endswith('/') and path_segment != "":
-                self.path = self.path if path_segment != "" else self.path + '/'
+                self.path = self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner,
                                          app=app, sharing=sharing)
         # ^-- This was "%s%s" % (self.path, path_segment).
@@ -845,7 +845,7 @@ class Endpoint(object):
             path = path_segment
         else:
             if not self.path.endswith('/') and path_segment != "":
-                self.path = self.path if path_segment != "" else self.path + '/'
+                self.path = self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner, app=app, sharing=sharing)
         return self.service.post(path, owner=owner, app=app, sharing=sharing, **query)
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -782,8 +782,8 @@ class Endpoint(object):
         if path_segment.startswith('/'):
             path = path_segment
         else:
-            if not self.path.endswith('/'):
-                self.path = self.path if self.path != "" and path_segment.startswith('/') else self.path + '/'
+            if not self.path.endswith('/') and path_segment != "":
+                self.path = self.path if path_segment.startswith('/') else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner,
                                          app=app, sharing=sharing)
         # ^-- This was "%s%s" % (self.path, path_segment).
@@ -844,9 +844,10 @@ class Endpoint(object):
         if path_segment.startswith('/'):
             path = path_segment
         else:
-            if not self.path.endswith('/'):
-                self.path = self.path if self.path != "" and path_segment.startswith('/') else self.path + '/'
+            if not self.path.endswith('/') and path_segment != "":
+                self.path = self.path if path_segment.startswith('/') else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner, app=app, sharing=sharing)
+        print(path)
         return self.service.post(path, owner=owner, app=app, sharing=sharing, **query)
 
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -783,7 +783,7 @@ class Endpoint(object):
             path = path_segment
         else:
             if not self.path.endswith('/') and path_segment != "":
-                self.path = self.path if path_segment.startswith('/') else self.path + '/'
+                self.path = self.path if path_segment != "" else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner,
                                          app=app, sharing=sharing)
         # ^-- This was "%s%s" % (self.path, path_segment).
@@ -845,7 +845,7 @@ class Endpoint(object):
             path = path_segment
         else:
             if not self.path.endswith('/') and path_segment != "":
-                self.path = self.path if path_segment.startswith('/') else self.path + '/'
+                self.path = self.path if path_segment != "" else self.path + '/'
             path = self.service._abspath(self.path + path_segment, owner=owner, app=app, sharing=sharing)
         return self.service.post(path, owner=owner, app=app, sharing=sharing, **query)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -167,6 +167,17 @@ class ServiceTestCase(testlib.SDKTestCase):
             'scheme': self.opts.kwargs['scheme']
         })
 
+    #To check the HEC event endpoint using Endpoint instance
+    def test_hec_event(self):
+        import json
+        service_hec = client.connect(host='localhost', scheme='https', port=8088,
+                                     token="11111111-1111-1111-1111-1111111111113")
+        event_collector_endpoint = client.Endpoint(service_hec, "/services/collector/event")
+        msg = {"index": "main", "event": "Hello World"}
+        response = event_collector_endpoint.post("", body=json.dumps(msg))
+        body = response.body.read()
+        self.assertEqual(body.code, 200)
+
 
 class TestCookieAuthentication(unittest.TestCase):
     def setUp(self):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -175,8 +175,7 @@ class ServiceTestCase(testlib.SDKTestCase):
         event_collector_endpoint = client.Endpoint(service_hec, "/services/collector/event")
         msg = {"index": "main", "event": "Hello World"}
         response = event_collector_endpoint.post("", body=json.dumps(msg))
-        body = response.body.read()
-        self.assertEqual(body.code, 200)
+        self.assertEqual(response.status,200)
 
 
 class TestCookieAuthentication(unittest.TestCase):


### PR DESCRIPTION
Fix for the Issue #345 

Previously `path` was always updated to `path + /`
This implementation fails while using the endpoint `/services/collector/event` as `/services/collector/event/` results in 404

The fix removes the hard coded addition of the `/` to all the paths, and it makes it conditional based on the presence of the `path_segment` for the `get/post` actions. If `path_segment' exists the `path` will be updated to `path + / `