### PR TITLE
Python3 compatibility for ResponseReader.__str__()

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1290,8 +1290,7 @@ class ResponseReader(io.RawIOBase):
         self._buffer = b''
 
     def __str__(self):
-        import sys
-        if sys.version_info[0] < 3:
+        if six.PY2:
             return self.read()
         else:
             return str(self.read(), 'UTF-8')

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1290,7 +1290,11 @@ class ResponseReader(io.RawIOBase):
         self._buffer = b''
 
     def __str__(self):
-        return self.read()
+        import sys
+        if sys.version_info[0] < 3:
+            return self.read()
+        else:
+            return str(self.read(), 'UTF-8')
 
     @property
     def empty(self):


### PR DESCRIPTION
- ResponseReader.__str__() is now Python3 compatible
- All tests are passing