### PR TITLE
Add distsearch.conf to Stream Search Command examples

### DIFF
--- a/examples/searchcommands_app/package/default/distsearch.conf
+++ b/examples/searchcommands_app/package/default/distsearch.conf
@@ -1,0 +1,7 @@
+# Valid in <=8.2
+[replicationWhitelist]
+searchcommands_app = apps/searchcommands_app/lib/...
+
+# Valid in >=8.3
+[replicationAllowlist]
+searchcommands_app = apps/searchcommands_app/lib/...

--- a/examples/searchcommands_template/default/distsearch.conf
+++ b/examples/searchcommands_template/default/distsearch.conf
@@ -1,0 +1,7 @@
+# Valid in <=8.2
+[replicationWhitelist]
+searchcommands_template = apps/searchcommands_template/lib/...
+
+# Valid in >=8.3
+[replicationAllowlist]
+searchcommands_template = apps/searchcommands_template/lib/...


### PR DESCRIPTION
The provided examples of Splunk Streaming Search Commands do not include a distsearch.conf, and as a result the streaming search command fail in a distributed search unless the app is also installed locally on all distributed search peers (indexers).

As per the Splunk Developer documentation at https://dev.splunk.com/enterprise/docs/devtools/customsearchcommands/packageanddeploycustom/#Deploy-a-streaming-command-on-an-indexer a distsearch.conf should be included so the lib directory is distributed.

I have also raised this as an issue https://github.com/splunk/splunk-sdk-python/issues/418

I have included both the classic (<=8.2) and new language-bias friendly (>=8.3) syntax for this configuration.
