### PR TITLE
Adding results.JSONReader

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_template.md
@@ -1,3 +1,12 @@
+---
+name: Pull Request Template
+about: Create a Pull Request to contribute to the SDK
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 ## Description of PR
 
 Provide the **context and motivation** for this PR. 

--- a/.github/PULL_REQUEST_TEMPLATE/pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_template.md
@@ -1,0 +1,21 @@
+## Description of PR
+
+Provide the **context and motivation** for this PR. 
+Briefly explain the **type of changes** (bug fix, feature request, doc update, etc.) made in this PR. Provide reference to issue # fixed, if applicable.
+
+Describe the approach to the solution, the changes made, and any resulting change in behavior or impact to the user.
+
+## Testing the changes
+
+Please ensure tests are added for your changes.
+Include details of **types of tests** written for the changes in the PR and any **test setup and configuration** required to run the tests.
+Mention the **versions of the SDK, language runtime, OS and details of Splunk deployment** used in testing.
+
+## Documentation
+
+Please ensure **comments** are added for your changes and any **relevant docs** (readme, reference docs, etc.) are updated.
+Include any references to documentation related to the changes.
+
+## Dependencies and other resources
+
+Provide references to PRs or things **dependent on this change** and any relevant PRs or resources like style guides and tools used in this PR.

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1291,7 +1291,9 @@ class ResponseReader(io.RawIOBase):
         self._buffer = b''
 
     def __str__(self):
-        return str(self.read())
+        if six.PY2:
+            return self.read()
+        return self.read().decode('utf-8')
 
     @property
     def empty(self) -> bool:

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -28,13 +28,14 @@ from __future__ import absolute_import
 
 import io
 import logging
+from os import PathLike
 import socket
 import ssl
 from base64 import b64encode
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
-from io import BytesIO
+from typing import Any
 from xml.etree.ElementTree import XML
 
 from splunklib import six
@@ -1042,7 +1043,7 @@ class AuthenticationError(HTTPError):
     def __init__(self, message, cause):
         # Put the body back in the response so that HTTPError's constructor can
         # read it again.
-        cause._response.body = BytesIO(cause.body)
+        cause._response.body = io.BytesIO(cause.body)
 
         HTTPError.__init__(self, cause._response, message)
 
@@ -1290,10 +1291,10 @@ class ResponseReader(io.RawIOBase):
         self._buffer = b''
 
     def __str__(self):
-        return self.read()
+        return str(self.read())
 
     @property
-    def empty(self):
+    def empty(self) -> bool:
         """Indicates whether there is any more data in the response."""
         return self.peek(1) == b""
 
@@ -1316,7 +1317,7 @@ class ResponseReader(io.RawIOBase):
             self._connection.close()
         self._response.close()
 
-    def read(self, size = None):
+    def read(self, size: int = None):
         """Reads a given number of characters from the response.
 
         :param size: The number of characters to read, or "None" to read the
@@ -1331,11 +1332,11 @@ class ResponseReader(io.RawIOBase):
         r = r + self._response.read(size)
         return r
 
-    def readable(self):
+    def readable(self) -> bool:
         """ Indicates that the response reader is readable."""
         return True
 
-    def readinto(self, byte_array):
+    def readinto(self, byte_array) -> int:
         """ Read data into a byte array, upto the size of the byte array.
 
         :param byte_array: A byte array/memory view to pour bytes into.
@@ -1349,7 +1350,12 @@ class ResponseReader(io.RawIOBase):
         return bytes_read
 
 
-def handler(key_file=None, cert_file=None, timeout=None, verify=False, context=None):
+def handler(
+    key_file: str = None,
+    cert_file: str = None,
+    timeout: int = None,
+    verify: bool=False,
+    context: ssl.SSLContext=None):
     """This class returns an instance of the default HTTP request handler using
     the values you provide.
 

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1085,7 +1085,7 @@ class Entity(Endpoint):
         return self
 
     @property
-    def state(self):
+    def state(self) -> dict:
         """Returns the entity's state record.
 
         :return: A ``dict`` containing fields and metadata for the entity.
@@ -3563,7 +3563,7 @@ class KVStoreCollection(Entity):
         :return: Result of POST request
         """
         kwargs = {}
-        kwargs['index.' + name] = value if isinstance(value, str) else json.dumps(value)
+        kwargs['index.' + name] = value if isinstance(value, six.string_types) else json.dumps(value)
         return self.post(**kwargs)
 
     def update_field(self, name, value):

--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -339,11 +339,16 @@ class JSONResultsReader(object):
         """Parse results and messages out of *stream*."""
         for line in stream.readlines():
 
-            event = json_loads(line)
-            if "preview" in event:
-                self.is_preview = event["preview"]
-            if "msg" in event:
-                msg_type = event.get("type", "Unknown Message Type")
-                text = event.get("text")
+            parsed_line = json_loads(line)
+            if "preview" in parsed_line:
+                self.is_preview = parsed_line["preview"]
+            if "messages" in parsed_line:
+                for message in parsed_line["messages"]:
+                    msg_type = message.get("type", "Unknown Message Type")
+                    text = message.get("text")
                 yield Message(msg_type, text)
-            yield event
+            if "result" in parsed_line:
+                yield parsed_line["result"]
+            if "results" in parsed_line:
+                for result in parsed_line["results"]:
+                    yield result

--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -343,7 +343,7 @@ class JSONResultsReader(object):
             if "preview" in event:
                 self.is_preview = event["preview"]
             if "msg" in event:
-                msg_type = event.get("type", "Uknown Message Type")
+                msg_type = event.get("type", "Unknown Message Type")
                 text = event.get("text")
                 yield Message(msg_type, text)
             yield event

--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -33,7 +33,7 @@ as follows:::
 """
 
 from __future__ import absolute_import
-
+from collections import OrderedDict
 from io import BufferedReader, BytesIO
 from json import loads as json_loads
 from splunklib import six
@@ -41,10 +41,6 @@ try:
     import xml.etree.cElementTree as et
 except ImportError:
     import xml.etree.ElementTree as et
-try:
-    from collections import OrderedDict  # must be python 2.7
-except ImportError:
-    from .ordereddict import OrderedDict
 
 __all__ = [
     "ResultsReader",


### PR DESCRIPTION
`results.ResultsReader` is slow because it's iterating byte-by-byte through the stream to parse the XML in a way the chosen parser will be happy. I've added JSONResultsReader to provide a much more performant option.

Benefits:
 - Less data transferred over the wire.
 - ~99% faster on most things I can test.

## Other changes in this commit

* Removed unnecessary imports.
* Fixed some places where indenting was 2 spaces, not 4.
* Renamed some input variables which aren't used by name, to match Python standards.

## Test Data

Running the tests from https://github.com/yaleman/splunk-sdk-games/ 

(you can just clone the repo, configure it and run `./run_tests.sh`)



Generating the local files, so that we're not testing the response of my Splunk instance:

```shell
➜ ./run_tests.sh
Generating local JSON data

real	0m25.155s
user	0m0.532s
sys	0m0.661s

Generating local XML data

real	0m29.173s
user	0m0.991s
sys	0m1.462s

File sizes

-rw-r--r--  1 yaleman  staff   161M 12 Feb 13:17 outputfile.json
-rw-r--r--  1 yaleman  staff   374M 12 Feb 13:17 outputfile.xml
```

Using `results.ResultsReader` and the job in XML output format:
```shell
Running test_file_resultsreader.py
message:  "INFO: Your timerange was substituted based on your search string"
Results: 113625
Preview results: 9963

real	2m2.416s
user	2m0.997s
sys	0m0.405s
```
Using `results.JSONResultsReader` and the job in JSON output format:

```shell
Running test_file_jsonreader.py
Results: 113624
Preview results: 12500

real	0m1.023s
user	0m0.856s
sys	0m0.090s
```

The 1 "missing" result is the `Message` that the JSON export endpoint doesn't return.