### PR TITLE
Modified POST method debug log to not log sensitive body/data

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -758,7 +758,13 @@ class Context(object):
             headers = []
 
         path = self.authority + self._abspath(path_segment, owner=owner, app=app, sharing=sharing)
-        logger.debug("POST request to %s (body: %s)", path, repr(query))
+
+        # To avoid writing sensitive data in debug logs
+        endpoint_having_sensitive_data = ["/storage/passwords"]
+        if any(endpoint in path for endpoint in endpoint_having_sensitive_data):
+            logger.debug("POST request to %s ", path)
+        else:
+            logger.debug("POST request to %s (body: %s)", path, repr(query))
         all_headers = headers + self.additional_headers + self._auth_headers
         response = self.http.post(path, all_headers, **query)
         return response


### PR DESCRIPTION
- This PR is fixed for the issue - 'splunklib logs user credentials in raw text'
- Added check to avoid writing sensitive data in debug logs
- ex. '/storage/passwords' endpoint is having password field in it's body during post method call