### PR TITLE
Create job support for "output_mode:json"

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -230,8 +230,7 @@ def _load_sid(response, output_mode):
     if output_mode == "json":
         json_obj = json.loads(response.body.read())
         return json_obj.get('sid')
-    else:
-        return _load_atom(response).response.sid
+    return _load_atom(response).response.sid
 
 
 # Parse the given atom entry record into a generic entity state record

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -226,8 +226,12 @@ def _load_atom_entries(response):
 
 
 # Load the sid from the body of the given response
-def _load_sid(response):
-    return _load_atom(response).response.sid
+def _load_sid(response, output_mode):
+    if output_mode == "json":
+        json_obj = json.loads(response.body.read())
+        return json_obj.get('sid')
+    else:
+        return _load_atom(response).response.sid
 
 
 # Parse the given atom entry record into a generic entity state record
@@ -2968,7 +2972,7 @@ class Jobs(Collection):
         if kwargs.get("exec_mode", None) == "oneshot":
             raise TypeError("Cannot specify exec_mode=oneshot; use the oneshot method instead.")
         response = self.post(search=query, **kwargs)
-        sid = _load_sid(response)
+        sid = _load_sid(response, kwargs.get("output_mode", None))
         return Job(self.service, sid)
 
     def export(self, query, **params):
@@ -3184,7 +3188,7 @@ class SavedSearch(Entity):
         :return: The :class:`Job`.
         """
         response = self.post("dispatch", **kwargs)
-        sid = _load_sid(response)
+        sid = _load_sid(response, kwargs.get("output_mode", None))
         return Job(self.service, sid)
 
     @property

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -48,6 +48,11 @@ class TestUtilities(testlib.SDKTestCase):
         self.assertTrue(job.sid in self.service.jobs)
         job.cancel()
 
+    def test_create_job_with_output_mode_json(self):
+        job = self.service.jobs.create(query='search index=_internal earliest=-1m | head 3', output_mode='json')
+        self.assertTrue(job.sid in self.service.jobs)
+        job.cancel()
+
     def test_oneshot_with_garbage_fails(self):
         jobs = self.service.jobs
         self.assertRaises(TypeError, jobs.create, "abcd", exec_mode="oneshot")


### PR DESCRIPTION
Added support for "output_mode='json'" while creating a job .