### PR TITLE
Set cookie issue 438

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -499,13 +499,13 @@ class Context(object):
         return self.http._cookies
 
     def has_cookies(self):
-        """Returns true if the ``HttpLib`` member of this instance has at least
-        one cookie stored.
+        """Returns true if the ``HttpLib`` member of this instance has auth token stored.
 
-        :return: ``True`` if there is at least one cookie, else ``False``
+        :return: ``True`` if there is auth token present, else ``False``
         :rtype: ``bool``
         """
-        return len(self.get_cookies()) > 0
+        auth_token_key = "splunkd_8089"
+        return auth_token_key in self.get_cookies().keys()
 
     # Shared per-context request headers
     @property

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -518,23 +518,23 @@ class Context(object):
 
         :returns: A list of 2-tuples containing key and value
         """
-        if self.has_cookies():
-            return [("Cookie", _make_cookie_header(list(self.get_cookies().items())))]
-        elif self.basic and (self.username and self.password):
-            token = 'Basic %s' % b64encode(("%s:%s" % (self.username, self.password)).encode('utf-8')).decode('ascii')
-            return [("Authorization", token)]
-        elif self.bearerToken:
-            token = 'Bearer %s' % self.bearerToken
-            return [("Authorization", token)]
-        elif self.token is _NoAuthenticationToken:
-            return []
-        else:
-            # Ensure the token is properly formatted
+        if self.token is not _NoAuthenticationToken:
             if self.token.startswith('Splunk '):
                 token = self.token
             else:
                 token = 'Splunk %s' % self.token
             return [("Authorization", token)]
+        elif self.bearerToken:
+            token = 'Bearer %s' % self.bearerToken
+            return [("Authorization", token)]
+        elif self.basic and (self.username and self.password):
+            token = 'Basic %s' % b64encode(("%s:%s" % (self.username, self.password)).encode('utf-8')).decode('ascii')
+            return [("Authorization", token)]
+        elif self.has_cookies():
+            return [("Cookie", _make_cookie_header(list(self.get_cookies().items())))]
+        else:
+            # no Authentication token
+            return []
 
     def connect(self):
         """Returns an open connection (socket) to the Splunk instance.

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -504,8 +504,8 @@ class Context(object):
         :return: ``True`` if there is auth token present, else ``False``
         :rtype: ``bool``
         """
-        auth_token_key = "splunkd_8089"
-        return auth_token_key in self.get_cookies().keys()
+        auth_token_key = "splunkd_"
+        return any(auth_token_key in key for key in self.get_cookies().keys())
 
     # Shared per-context request headers
     @property

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -518,23 +518,23 @@ class Context(object):
 
         :returns: A list of 2-tuples containing key and value
         """
-        if self.token is not _NoAuthenticationToken:
+        if self.has_cookies():
+            return [("Cookie", _make_cookie_header(list(self.get_cookies().items())))]
+        elif self.basic and (self.username and self.password):
+            token = 'Basic %s' % b64encode(("%s:%s" % (self.username, self.password)).encode('utf-8')).decode('ascii')
+            return [("Authorization", token)]
+        elif self.bearerToken:
+            token = 'Bearer %s' % self.bearerToken
+            return [("Authorization", token)]
+        elif self.token is _NoAuthenticationToken:
+            return []
+        else:
+            # Ensure the token is properly formatted
             if self.token.startswith('Splunk '):
                 token = self.token
             else:
                 token = 'Splunk %s' % self.token
             return [("Authorization", token)]
-        elif self.bearerToken:
-            token = 'Bearer %s' % self.bearerToken
-            return [("Authorization", token)]
-        elif self.basic and (self.username and self.password):
-            token = 'Basic %s' % b64encode(("%s:%s" % (self.username, self.password)).encode('utf-8')).decode('ascii')
-            return [("Authorization", token)]
-        elif self.has_cookies():
-            return [("Cookie", _make_cookie_header(list(self.get_cookies().items())))]
-        else:
-            # no Authentication token
-            return []
 
     def connect(self):
         """Returns an open connection (socket) to the Splunk instance.

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -586,23 +586,22 @@ class TestCookieAuthentication(unittest.TestCase):
         self.assertTrue(found)
 
     def test_login_fails_with_bad_cookie(self):
-        new_context = binding.connect(**{"cookie": "bad=cookie"})
         # We should get an error if using a bad cookie
         try:
-            new_context.get("apps/local")
+            new_context = binding.connect(**{"cookie": "bad=cookie"})
             self.fail()
         except AuthenticationError as ae:
-            self.assertEqual(str(ae), "Request failed: Session is not logged in.")
+            self.assertEqual(str(ae), "Login failed.")
 
     def test_login_with_multiple_cookies(self):
-        bad_cookie = 'bad=cookie'
-        new_context = binding.connect(**{"cookie": bad_cookie})
         # We should get an error if using a bad cookie
+        new_context = binding.Context()
+        new_context.get_cookies().update({"bad": "cookie"})
         try:
-            new_context.get("apps/local")
+            new_context = new_context.login()
             self.fail()
         except AuthenticationError as ae:
-            self.assertEqual(str(ae), "Request failed: Session is not logged in.")
+            self.assertEqual(str(ae), "Login failed.")
             # Bring in a valid cookie now
             for key, value in self.context.get_cookies().items():
                 new_context.get_cookies()[key] = value

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -214,15 +214,14 @@ class TestCookieAuthentication(unittest.TestCase):
         service2 = client.Service()
         self.assertEqual(len(service2.get_cookies()), 0)
         service2.get_cookies().update(bad_cookie)
-        service2.login()
         self.assertEqual(service2.get_cookies(), {'bad': 'cookie'})
 
         # Should get an error with a bad cookie
         try:
-            service2.apps.get()
+            service2.login()
             self.fail()
         except AuthenticationError as ae:
-            self.assertEqual(str(ae), "Request failed: Session is not logged in.")
+            self.assertEqual(str(ae), "Login failed.")
 
     def test_autologin_with_cookie(self):
         self.service.login()
@@ -264,14 +263,13 @@ class TestCookieAuthentication(unittest.TestCase):
         self.assertIsNotNone(self.service.get_cookies())
 
         service2 = client.Service(**{"cookie": bad_cookie})
-        service2.login()
 
         # Should get an error with a bad cookie
         try:
-            service2.apps.get()
+            service2.login()
             self.fail()
         except AuthenticationError as ae:
-            self.assertEqual(str(ae), "Request failed: Session is not logged in.")
+            self.assertEqual(str(ae), "Login failed.")
 
             # Add on valid cookies, and try to use all of them
             service2.get_cookies().update(self.service.get_cookies())


### PR DESCRIPTION
Changes in response to the issue [#438](https://github.com/splunk/splunk-sdk-python/issues/438)
- Updated the hasCookie method to check for the cookie received from Splunk (i.e "splunkd_<port>") instead of the existing length check.
- Updated the test cases with respect to the code changes.