### PR TITLE
Remove restart from client.Entity.disable

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1095,8 +1095,6 @@ class Entity(Endpoint):
     def disable(self):
         """Disables the entity at this endpoint."""
         self.post("disable")
-        if self.service.restart_required:
-            self.service.restart(120)
         return self
 
     def enable(self):


### PR DESCRIPTION
restart() call has been removed from the client.Entity.disable method