### PR TITLE
UnicodeDecodeError caught for json_loads

### DIFF
--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -358,7 +358,12 @@ class JSONResultsReader(object):
         for line in stream.readlines():
             strip_line = line.strip()
             if strip_line.__len__() == 0: continue
-            parsed_line = json_loads(strip_line)
+            try:
+                parsed_line = json_loads(strip_line)
+            except UnicodeDecodeError:
+                # If UnicodeDecodeError is encountered, ignoring decode errors should ensure the
+                # line can be loaded; may be beneficial to raise a warning at this point.
+                parsed_line = json_loads(strip_line.decode(encoding="utf-8", errors="ignore"))
             if "preview" in parsed_line:
                 self.is_preview = parsed_line["preview"]
             if "messages" in parsed_line and parsed_line["messages"].__len__() > 0:


### PR DESCRIPTION
Hi, I encountered a `UnicodeDecodeError` when reading some data that was quite badly corrupted. This occurred when iterating through a `JSONResultsReader`. Error occurred using Python 3.10.5.

Error was:

`UnicodeDecodeError: 'utf-8' codec can't decode byte [val] in position [val]: invalid continuation byte`

The stacktrace points to `json.loads` (imported as `json_loads`) - this pull request catches the exception and re-reads, ignoring the decode error. It may be beneficial to raise a warning to the user, but apologies as I'm not familiar enough with the codebase for that just yet :)