### PR TITLE
Added 'kwrgs' parameter for Saved Search History function

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -3212,12 +3212,15 @@ class SavedSearch(Entity):
             item=AlertGroup)
         return c
 
-    def history(self):
+    def history(self, **kwargs):
         """Returns a list of search jobs corresponding to this saved search.
+
+        :param `kwargs`: Additional arguments (optional).
+        :type kwargs: ``dict``
 
         :return: A list of :class:`Job` objects.
         """
-        response = self.get("history")
+        response = self.get("history", **kwargs)
         entries = _load_atom_entries(response)
         if entries is None: return []
         jobs = []

--- a/tests/test_saved_search.py
+++ b/tests/test_saved_search.py
@@ -170,6 +170,27 @@ class TestSavedSearch(testlib.SDKTestCase):
         finally:
             job.cancel()
 
+    def test_history_with_options(self):
+        try:
+            old_jobs = self.saved_search.history()
+            old_jobs_cnt = len(old_jobs)
+
+            curr_job_cnt = 50
+            for _ in range(curr_job_cnt):
+                job = self.saved_search.dispatch()
+                while not job.is_ready():
+                    sleep(0.1)
+
+            # fetching all the jobs
+            history = self.saved_search.history(count=0)
+            self.assertEqual(len(history), old_jobs_cnt + curr_job_cnt)
+
+            # fetching 3 jobs
+            history = self.saved_search.history(count=3)
+            self.assertEqual(len(history), 3)
+        finally:
+            job.cancel()
+
     def test_scheduled_times(self):
         self.saved_search.update(cron_schedule='*/5 * * * *', is_scheduled=True)
         scheduled_times = self.saved_search.scheduled_times()


### PR DESCRIPTION
- added support for passing additional arguments in saved search history method
- fix for the issue - previously max 30 jobs were returned
- now we can use count argument and specify job count, (set count=0 for all the jobs)