### PR TITLE
Added ACL properties update feature

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1216,6 +1216,36 @@ class Entity(Endpoint):
         self.post("_reload")
         return self
 
+    def acl_update(self, **kwargs):
+        """To update Access Control List (ACL) properties for an endpoint.
+
+        :param kwargs: Additional entity-specific arguments (required).
+
+            - "owner" (``string``): The Splunk username, such as "admin". A value of "nobody" means no specific user (required).
+
+            - "sharing" (``string``): A mode that indicates how the resource is shared. The sharing mode can be "user", "app", "global", or "system" (required).
+
+        :type kwargs: ``dict``
+
+        **Example**::
+
+            import splunklib.client as client
+            service = client.connect(...)
+            saved_search = service.saved_searches["name"]
+            saved_search.acl_update(sharing="app", owner="nobody", app="search", **{"perms.read": "admin, nobody"})
+        """
+        if "body" not in kwargs:
+            kwargs = {"body": {**kwargs}}
+
+        if "sharing" not in kwargs["body"]:
+            raise ValueError("Required argument 'sharing' is missing.")
+        if "owner" not in kwargs["body"]:
+            raise ValueError("Required argument 'owner' is missing.")
+
+        self.post("acl", **kwargs)
+        self.refresh()
+        return self
+
     @property
     def state(self):
         """Returns the entity's state record.

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1235,7 +1235,7 @@ class Entity(Endpoint):
             saved_search.acl_update(sharing="app", owner="nobody", app="search", **{"perms.read": "admin, nobody"})
         """
         if "body" not in kwargs:
-            kwargs = {"body": {**kwargs}}
+            kwargs = {"body": kwargs}
 
         if "sharing" not in kwargs["body"]:
             raise ValueError("Required argument 'sharing' is missing.")

--- a/tests/test_saved_search.py
+++ b/tests/test_saved_search.py
@@ -223,6 +223,30 @@ class TestSavedSearch(testlib.SDKTestCase):
         self.saved_search.unsuppress()
         self.assertEqual(self.saved_search['suppressed'], 0)
 
+    def test_acl(self):
+        self.assertEqual(self.saved_search.access["perms"], None)
+        self.saved_search.acl_update(sharing="app", owner="admin", app="search", **{"perms.read": "admin, nobody"})
+        self.assertEqual(self.saved_search.access["owner"], "admin")
+        self.assertEqual(self.saved_search.access["app"], "search")
+        self.assertEqual(self.saved_search.access["sharing"], "app")
+        self.assertEqual(self.saved_search.access["perms"]["read"], ['admin', 'nobody'])
+
+    def test_acl_fails_without_sharing(self):
+        self.assertRaisesRegex(
+            ValueError,
+            "Required argument 'sharing' is missing.",
+            self.saved_search.acl_update,
+            owner="admin", app="search", **{"perms.read": "admin, nobody"}
+        )
+
+    def test_acl_fails_without_owner(self):
+        self.assertRaisesRegex(
+            ValueError,
+            "Required argument 'owner' is missing.",
+            self.saved_search.acl_update,
+            sharing="app", app="search", **{"perms.read": "admin, nobody"}
+        )
+
 if __name__ == "__main__":
     try:
         import unittest2 as unittest


### PR DESCRIPTION
Added new acl_update() method which will calls the `/acl` endpoint for particular entity and update it's ACL properties according to the arguments passed. changes wrt issue #481 . 