### PR TITLE
Add dependabot and add Splunk 8.1 to tests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
           - ubuntu-latest
         python: [ 2.7, 3.7 ]
         splunk-version:
+          - "8.1"
           - "8.2"
           - "latest"
       fail-fast: false


### PR DESCRIPTION
Splunk 8.1 is still supported: https://www.splunk.com/en_us/legal/splunk-software-support-policy.html