### PR TITLE
non-utf8-bugfix

### DIFF
--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -77,7 +77,7 @@ class EventWriter(object):
 
         :param document: An ``ElementTree`` object.
         """
-        self._out.write(ensure_str(ET.tostring(document)))
+        self._out.write(ensure_str(ET.tostring(document), errors="replace"))
         self._out.flush()
 
     def close(self):

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -934,7 +934,7 @@ class SearchCommand(object):
         except Exception as error:
             raise RuntimeError('Failed to read body of length {}: {}'.format(body_length, error))
 
-        return metadata, six.ensure_str(body)
+        return metadata, six.ensure_str(body, errors="replace")
 
     _header = re.compile(r'chunked\s+1.0\s*,\s*(\d+)\s*,\s*(\d+)\s*\n')
 

--- a/splunklib/six.py
+++ b/splunklib/six.py
@@ -898,7 +898,7 @@ def ensure_binary(s, encoding='utf-8', errors='strict'):
         raise TypeError("not expecting type '%s'" % type(s))
 
 
-def ensure_str(s, encoding='utf-8', errors='strict'):
+def ensure_str(s, encoding='utf-8', errors='replace'):
     """Coerce *s* to `str`.
 
     For Python 2:

--- a/splunklib/six.py
+++ b/splunklib/six.py
@@ -898,7 +898,7 @@ def ensure_binary(s, encoding='utf-8', errors='strict'):
         raise TypeError("not expecting type '%s'" % type(s))
 
 
-def ensure_str(s, encoding='utf-8', errors='replace'):
+def ensure_str(s, encoding='utf-8', errors='strict'):
     """Coerce *s* to `str`.
 
     For Python 2:


### PR DESCRIPTION
- replaced 'strict' error checking with 'replace'