### PR TITLE
Update to binding.py

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1457,7 +1457,7 @@ def handler(key_file=None, cert_file=None, timeout=None, verify=False, context=N
         body = message.get("body", "")
         head = {
             "Content-Length": str(len(body)),
-            "Host": host,
+            "Host": "%s:%d" % (host, port),
             "User-Agent": "splunk-sdk-python/%s" % __version__,
             "Accept": "*/*",
             "Connection": "Close",


### PR DESCRIPTION
Although port number in HTTP Host header is not mandatory, it may be used by load balancer to route traffic to the right cluster.
Change is very simple and adds ":port" part to the Host HTTP header.