### PR TITLE
DVPL-12129_investigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tests/searchcommands/apps/app_with_logging_configuration/*.log
 venv/
 .tox
 test-reports/
+.venv/
+orca.json
+__pycache__/

--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -772,14 +772,18 @@ class RecordWriterV2(RecordWriter):
     def flush(self, finished=None, partial=None):
 
         RecordWriter.flush(self, finished, partial)  # validates arguments and the state of this instance
+ 
+        if partial:
+            finished = False
 
-        if partial or not finished:
-            # Don't flush partial chunks, since the SCP v2 protocol does not
-            # provide a way to send partial chunks yet.
-            return
+        # self.write_chunk(finished)
 
+        # Note: when the stdout buffer is flushed, it does not mean we are "finished"
         if not self.is_flushed:
-            self.write_chunk(finished=True)
+            self.write_chunk(finished)
+        elif finished:
+            self._write_chunk((('finished', True),), '')
+            # self.write_chunk(finished)
 
     def write_chunk(self, finished=None):
         inspector = self._inspector
@@ -841,4 +845,4 @@ class RecordWriterV2(RecordWriter):
         self.write(metadata)
         self.write(body)
         self._ofile.flush()
-        self._flushed = True
+        self._flushed = False

--- a/tests/searchcommands/test_internals_v2.py
+++ b/tests/searchcommands/test_internals_v2.py
@@ -136,7 +136,7 @@ class TestInternals(TestCase):
 
         write_record = writer.write_record
 
-        for serial_number in range(0, 31):
+        for serial_number in range(0, 502):
             values = [serial_number, time(), random_bytes(), random_dict(), random_integers(), random_unicode()]
             record = OrderedDict(izip(fieldnames, values))
             #try:
@@ -170,12 +170,12 @@ class TestInternals(TestCase):
         for name, metric in six.iteritems(metrics):
             writer.write_metric(name, metric)
 
-        self.assertEqual(writer._chunk_count, 0)
-        self.assertEqual(writer._record_count, 31)
-        self.assertEqual(writer.pending_record_count, 31)
+        self.assertEqual(writer._chunk_count, 50)
+        self.assertEqual(writer._record_count, 2)
+        self.assertEqual(writer.pending_record_count, 2)
         self.assertGreater(writer._buffer.tell(), 0)
-        self.assertEqual(writer._total_record_count, 0)
-        self.assertEqual(writer.committed_record_count, 0)
+        self.assertEqual(writer._total_record_count, 500)
+        self.assertEqual(writer.committed_record_count, 500)
         fieldnames.sort()
         writer._fieldnames.sort()
         self.assertListEqual(writer._fieldnames, fieldnames)
@@ -185,15 +185,15 @@ class TestInternals(TestCase):
             dict(ifilter(lambda k_v: k_v[0].startswith('metric.'), six.iteritems(writer._inspector))),
             dict(imap(lambda k_v1: ('metric.' + k_v1[0], k_v1[1]), six.iteritems(metrics))))
 
-        writer.flush(finished=True)
+        writer.flush(partial=True)
 
-        self.assertEqual(writer._chunk_count, 1)
+        self.assertEqual(writer._chunk_count, 51)
         self.assertEqual(writer._record_count, 0)
         self.assertEqual(writer.pending_record_count, 0)
         self.assertEqual(writer._buffer.tell(), 0)
         self.assertEqual(writer._buffer.getvalue(), '')
-        self.assertEqual(writer._total_record_count, 31)
-        self.assertEqual(writer.committed_record_count, 31)
+        self.assertEqual(writer._total_record_count, 502)
+        self.assertEqual(writer.committed_record_count, 502)
 
         self.assertRaises(AssertionError, writer.flush, finished=True, partial=True)
         self.assertRaises(AssertionError, writer.flush, finished='non-boolean')

--- a/tests/searchcommands/test_reporting_command.py
+++ b/tests/searchcommands/test_reporting_command.py
@@ -10,7 +10,7 @@ def test_simple_reporting_command():
         def reduce(self, records):
             value = 0
             for record in records:
-                value += int(record["value"])
+                value += int(record.get("value"))
             yield {'sum': value}
 
     cmd = TestReportingCommand()


### PR DESCRIPTION
* Related issue #541 
* Findings
  * Behavior change since 1.6.15 from #301 
  * `SearchCommand._execute_v2()` writes records as soon as a result from the chunk is processed, rather than capturing a generator of all the records from the chunk, and then writing.
* Reverting a few logics
  * Reintroduced `SearchCommand._records_protocol_v2`
* Remaining action items
  * May need to refactor `SearchCommand._records_protocol_v2()` to leverage `SearchCommand._read_csv_records()`, though the reading may need to be processed in a higher layer.
  * May need to refactor `SearchCommand._execute_v2()`, since it is only used by `generating_command.py`, as such we may want a common abstract interface for all commands using the v2 protocol.
  * Regression testings