### PR TITLE
Add "deprecation" package as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,10 @@ setup(
                 "splunklib.modularinput",
                 "splunklib.searchcommands"],
 
+    install_requires=[
+        "deprecation",
+    ],
+
     url="http://github.com/splunk/splunk-sdk-python",
 
     version=splunklib.__version__,


### PR DESCRIPTION
Fixes https://github.com/splunk/splunk-sdk-python/issues/548#issuecomment-2014425756