### PR TITLE
fix: delete in binding.py now same as get/post

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -662,8 +662,9 @@ class Context:
         """
         path = self.authority + self._abspath(path_segment, owner=owner,
                                               app=app, sharing=sharing)
+        all_headers = headers + self.additional_headers + self._auth_headers
         logger.debug("DELETE request to %s (body: %s)", path, mask_sensitive_data(query))
-        response = self.http.delete(path, self._auth_headers, **query)
+        response = self.http.delete(path, all_headers, **query)
         return response
 
     @_authentication


### PR DESCRIPTION
Currently you can not pass custom headers to delete, as they are overwritten with default self._auth_headers. Replaced that with all_headers as in get and put.