### PR TITLE
Fix invalid escape sequence in get_api_version func

### DIFF
--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -769,7 +769,7 @@ class Endpoint:
         # For example, "/services/search/jobs" is using API v1
         api_version = 1
 
-        versionSearch = re.search('(?:servicesNS\/[^/]+\/[^/]+|services)\/[^/]+\/v(\d+)\/', path)
+        versionSearch = re.search(r'(?:servicesNS\/[^/]+\/[^/]+|services)\/[^/]+\/v(\d+)\/', path)
         if versionSearch:
             api_version = int(versionSearch.group(1))
 


### PR DESCRIPTION
Linked issue: https://github.com/splunk/splunk-sdk-python/issues/582