### PR TITLE
Revert "DVPL-0: don't use latest splunk version because of HEC token …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,7 @@ jobs:
         splunk-version:
           - "8.1"
           - "8.2"
-          - "9.0.8"
-          - "9.1.3"
+          - "latest"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
…issue"

This reverts commit 40e7b2a305d8e67034c13711c41c678e3a8d9fc5.