### PR TITLE
Use relative imports for splunk-sdk

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -39,8 +39,8 @@ from urllib import parse
 from http import client
 from http.cookies import SimpleCookie
 from xml.etree.ElementTree import XML, ParseError
-from splunklib.data import record
-from splunklib import __version__
+from .data import record
+from . import __version__
 
 
 logger = logging.getLogger(__name__)

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -68,9 +68,9 @@ from datetime import datetime, timedelta
 from time import sleep
 from urllib import parse
 
-from splunklib import data
-from splunklib.data import record
-from splunklib.binding import (AuthenticationError, Context, HTTPError, UrlEncoded,
+from . import data
+from .data import record
+from .binding import (AuthenticationError, Context, HTTPError, UrlEncoded,
                                _encode, _make_cookie_header, _NoAuthenticationToken,
                                namespace)
 

--- a/splunklib/modularinput/event.py
+++ b/splunklib/modularinput/event.py
@@ -15,7 +15,7 @@
 from io import TextIOBase
 import xml.etree.ElementTree as ET
 
-from splunklib.utils import ensure_str
+from ..utils import ensure_str
 
 
 class Event:

--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -15,7 +15,7 @@
 import sys
 import traceback
 
-from splunklib.utils import ensure_str
+from ..utils import ensure_str
 from .event import ET
 
 

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -34,11 +34,8 @@ from urllib.parse import unquote
 from urllib.parse import urlsplit
 from warnings import warn
 from xml.etree import ElementTree
-from splunklib.utils import ensure_str
-
 
 # Relative imports
-import splunklib
 from . import Boolean, Option, environment
 from .internals import (
     CommandLineParser,
@@ -53,6 +50,7 @@ from .internals import (
     RecordWriterV2,
     json_encode_string)
 from ..client import Service
+from ..utils import ensure_str
 
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Referencing https://github.com/splunk/splunk-sdk-python/pull/163 where there was an effort to use relative imports. There are still some spots where there are not relative imports. 

Using relative imports also makes it easier to vendor splunklib. 