### PR TITLE
Add devcontainer (Codespaces configuration)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/bin/python3.9"
+            }
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "version": "latest",
+            "azureDnsAutoDetection": false,
+            "dockerDefaultAddressPool": "base=192.168.0.0/16,size=24"
+        }
+    },
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "16gb",
+        "storage": "32gb"
+    },
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "onCreateCommand": ".devcontainer/on-create-command.sh"
+}

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -13,3 +13,7 @@ sudo apt update && sudo apt install -y python3.7 python3.7-venv python3.9 python
 
 # Install pip and tox for Python 3.7
 python3.7 -m ensurepip && python3.7 -m pip --disable-pip-version-check --no-cache-dir install tox
+
+# Set permissions on splunklib/ for
+# tests/test_utils.py::FilePermissionTest::test_filePermissions
+sudo find splunklib/ -type f -iname "*.py" -exec chmod 0644 {} \;

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# Install add-apt-repository
+sudo apt update && sudo apt install -y software-properties-common
+
+# Add the deadsnakes ppa for Python 3.7 and Python 3.9
+# https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa
+sudo add-apt-repository -y ppa:deadsnakes/ppa
+
+# Install Python 3.7 and 3.9
+sudo apt update && sudo apt install -y python3.7 python3.7-venv python3.9 python3.9-venv
+
+# Install pip and tox for Python 3.7
+python3.7 -m ensurepip && python3.7 -m pip --disable-pip-version-check --no-cache-dir install tox


### PR DESCRIPTION
This PR adds a `.devcontainer/devcontainer.json` file that can be used by [GitHub Codespaces](https://github.com/features/codespaces).

Creating a Codespace from this branch gives users a Codespace based on Ubuntu Jammy (22.04) with Python 3.7 and Python 3.9 (from the [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa)) already installed along with Docker and `tox`. This should make it trivial for anyone to create a development environment and run tests within a minute or two.

## Testing this PR

1. Create a new Codespace from this branch
2. Follow the [Testing Quickstart instructions](https://github.com/splunk/splunk-sdk-python/blob/master/README.md#testing-quickstart)
3. Verify that all tests pass (using Python 3.7 and Python 3.9 against Splunk version 9.2)