### PR TITLE
Revert "Use relative imports for splunk-sdk"

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -39,8 +39,8 @@ from urllib import parse
 from http import client
 from http.cookies import SimpleCookie
 from xml.etree.ElementTree import XML, ParseError
-from .data import record
-from . import __version__
+from splunklib.data import record
+from splunklib import __version__
 
 
 logger = logging.getLogger(__name__)

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -68,9 +68,9 @@ from datetime import datetime, timedelta
 from time import sleep
 from urllib import parse
 
-from . import data
-from .data import record
-from .binding import (AuthenticationError, Context, HTTPError, UrlEncoded,
+from splunklib import data
+from splunklib.data import record
+from splunklib.binding import (AuthenticationError, Context, HTTPError, UrlEncoded,
                                _encode, _make_cookie_header, _NoAuthenticationToken,
                                namespace)
 

--- a/splunklib/modularinput/event.py
+++ b/splunklib/modularinput/event.py
@@ -15,7 +15,7 @@
 from io import TextIOBase
 import xml.etree.ElementTree as ET
 
-from ..utils import ensure_str
+from splunklib.utils import ensure_str
 
 
 class Event:

--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -15,7 +15,7 @@
 import sys
 import traceback
 
-from ..utils import ensure_str
+from splunklib.utils import ensure_str
 from .event import ET
 
 

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -34,8 +34,11 @@ from urllib.parse import unquote
 from urllib.parse import urlsplit
 from warnings import warn
 from xml.etree import ElementTree
+from splunklib.utils import ensure_str
+
 
 # Relative imports
+import splunklib
 from . import Boolean, Option, environment
 from .internals import (
     CommandLineParser,
@@ -50,7 +53,6 @@ from .internals import (
     RecordWriterV2,
     json_encode_string)
 from ..client import Service
-from ..utils import ensure_str
 
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Reverts splunk/splunk-sdk-python#602

we shouldn't  directly merge to master