### PR TITLE
Set autologin=True while running tests.

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -26,7 +26,8 @@ from splunklib.binding import HTTPError
 
 class ServiceTestCase(testlib.SDKTestCase):
     def test_autologin(self):
-        service = client.connect(autologin=True, **self.opts.kwargs)
+        self.assertTrue(self.opts.kwargs.get("autologin"))
+        service = client.connect(**self.opts.kwargs)
         self.service.restart(timeout=120)
         reader = service.jobs.oneshot("search index=internal | head 1")
         self.assertIsNotNone(reader)

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -233,7 +233,7 @@ class SDKTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.opts = parse([], {}, ".env")
-        cls.opts.kwargs.update({"retries": 3})
+        cls.opts.kwargs.update({"retries": 3, "autologin": True})
         # Before we start, make sure splunk doesn't need a restart.
         service = client.connect(**cls.opts.kwargs)
         if service.restart_required:


### PR DESCRIPTION
When autologin is set to False, the client does not attempt to re-authenticate on a 401 response and instead fails with an AuthenticationError.