### PR TITLE
Set SPLUNK_GENERAL_TERMS env in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
         container_name: splunk
         environment:
             - SPLUNK_START_ARGS=--accept-license
+            - SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com
             - SPLUNK_HEC_TOKEN=11111111-1111-1111-1111-1111111111113
             - SPLUNK_PASSWORD=changed!
             - SPLUNK_APPS_URL=https://github.com/splunk/sdk-app-collection/releases/download/v1.1.0/sdkappcollection.tgz


### PR DESCRIPTION
This setting is required for Splunk 10.

See https://lantern.splunk.com/Splunk_Platform/Product_Tips/Upgrades_and_Migration/Preparing_to_upgrade_from_9.x_to_Splunk_Enterprise_and_Cloud_Platform_10.0#section_16