### PR TITLE
Mark non-test classes with __test__ = False attribute

### DIFF
--- a/tests/searchcommands/test_decorators.py
+++ b/tests/searchcommands/test_decorators.py
@@ -32,6 +32,8 @@ from tests.searchcommands import rebase_environment
 
 @Configuration()
 class TestSearchCommand(SearchCommand):
+    __test__ = False
+
     boolean = Option(
         doc="""
         **Syntax:** **boolean=***<value>*

--- a/tests/searchcommands/test_internals_v2.py
+++ b/tests/searchcommands/test_internals_v2.py
@@ -300,6 +300,8 @@ class TestInternals(TestCase):
 
 
 class TestRecorder:
+    __test__ = False
+
     def __init__(self, test_case):
         self._test_case = test_case
         self._output = None
@@ -389,6 +391,8 @@ def recorded(method):
 
 
 class Test:
+    __test__ = False
+
     def __init__(self, fieldnames, data_generators):
         TestCase.__init__(self)
         self._data_generators = list(

--- a/tests/searchcommands/test_search_command.py
+++ b/tests/searchcommands/test_search_command.py
@@ -55,6 +55,8 @@ def build_command_input(getinfo_metadata, execute_metadata, execute_body):
 
 @Configuration()
 class TestCommand(SearchCommand):
+    __test__ = False
+
     required_option_1 = Option(require=True)
     required_option_2 = Option(require=True)
 
@@ -99,6 +101,8 @@ class TestCommand(SearchCommand):
 
 @Configuration()
 class TestStreamingCommand(StreamingCommand):
+    __test__ = False
+
     def stream(self, records):
         serial_number = 0
         for record in records:


### PR DESCRIPTION
This resolves few warnings that were emitted by pytest.

See: https://docs.pytest.org/en/stable/example/pythoncollection.html#customizing-test-collection