### PR TITLE
NOJIRA: Change dependabot target branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "develop"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Current configuration provides no benefit to us. It makes more sense for us to bump deps in `develop` instead.