### PR TITLE
Remove unchecked splunk restart in test_modular_input_kinds.py

### DIFF
--- a/tests/integration/test_modular_input_kinds.py
+++ b/tests/integration/test_modular_input_kinds.py
@@ -22,10 +22,6 @@ from splunklib import client
 
 
 class ModularInputKindTestCase(testlib.SDKTestCase):
-    def setUp(self):
-        super().setUp()
-        self.uncheckedRestartSplunk()
-
     @pytest.mark.app
     def test_list_arguments(self):
         self.install_app_from_collection("modular_inputs")

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -221,9 +221,6 @@ class SDKTestCase(unittest.TestCase):
         appPath = separator.join([splunkHome, "etc", "apps", appName] + pathComponents)
         return appPath
 
-    def uncheckedRestartSplunk(self, timeout=240):
-        self.service.restart(timeout)
-
     def restartSplunk(self, timeout=240):
         if self.service.restart_required:
             self.service.restart(timeout)


### PR DESCRIPTION
These do not seem to be necessary, `install_app_from_collection` internally handles restarting of splunk. Also other tests that call `install_app_from_collection` do not restart splunk before.