### PR TITLE
Update release workflow to build wheel package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: pip install twine
       - name: Build package
-        run: python setup.py sdist
+        run: python setup.py sdist bdist_wheel
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@d417ba7e7683fa9104c42abe611c1f2c93c0727d
         with:


### PR DESCRIPTION
## Validation
### Installing from the wheel
```
(splunk-sdk-python) ~/src/splunk-sdk-python (sodle) › pip install ./dist/splunk_sdk-2.1.0-py3-none-any.whl  (master) ✔
Looking in indexes: https://tok.sodle%40splunk.com:****@repo.splunkdev.net/artifactory/api/pypi/pypi-test/simple
Processing ./dist/splunk_sdk-2.1.0-py3-none-any.whl
Collecting deprecation (from splunk-sdk==2.1.0)
  Downloading https://repo.splunkdev.net/artifactory/api/pypi/pypi-test/packages/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl (11 kB)
Requirement already satisfied: packaging in ./.venv/lib/python3.13/site-packages (from deprecation->splunk-sdk==2.1.0) (25.0)
Installing collected packages: deprecation, splunk-sdk
Successfully installed deprecation-2.1.0 splunk-sdk-2.1.0
```

### Using the package from the wheel
```
Python 3.13.3 (main, Apr  9 2025, 03:47:57) [Clang 20.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from splunklib import client
>>> client.__file__
'/Users/sodle/src/splunk-sdk-python/.venv/lib/python3.13/site-packages/splunklib/client.py'
>>> service = client.connect(host='localhost', port=8089, username='admin', password='password', verify=False)
>>> service.indexes
<splunklib.client.Indexes object at 0x104a83230>
>>> service.indexes.list()
[<splunklib.client.Index object at 0x104a83620>, <splunklib.client.Index object at 0x104c80050>, <splunklib.client.Index object at 0x104c80190>, <splunklib.client.Index object at 0x104a73360>, <splunklib.client.Index object at 0x104a73490>, <splunklib.client.Index object at 0x104af72f0>, <splunklib.client.Index object at 0x10492e030>, <splunklib.client.Index object at 0x10492e580>, <splunklib.client.Index object at 0x1047ace50>, <splunklib.client.Index object at 0x104b60550>, <splunklib.client.Index object at 0x1048f6b70>, <splunklib.client.Index object at 0x1048f66c0>, <splunklib.client.Index object at 0x1047d9a90>]
>>> [idx.name for idx in service.indexes.list()]
['_audit', '_configtracker', '_dsappevent', '_dsclient', '_dsphonehome', '_internal', '_introspection', '_telemetry', '_thefishbucket', 'history', 'main', 'splunklogger', 'summary']
>>> 
```
