### PR TITLE
Resolve warnings emitted by tests

### DIFF
--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -148,7 +148,7 @@ class _XMLDTDFilter:
 
 
 @deprecation.deprecated(
-    details="Use the JSONResultsReader function instead in conjuction with the 'output_mode' query param set to 'json'"
+    details="Use the JSONResultsReader function instead in conjunction with the 'output_mode' query param set to 'json'"
 )
 class ResultsReader:
     """This class returns dictionaries and Splunk messages from an XML results

--- a/tests/integration/test_job.py
+++ b/tests/integration/test_job.py
@@ -30,6 +30,7 @@ from splunklib import results
 from splunklib.binding import _log_duration, HTTPError
 
 import pytest
+import warnings
 
 
 class TestUtilities(testlib.SDKTestCase):
@@ -446,22 +447,25 @@ class TestResultsReader(unittest.TestCase):
         test_dir = Path(__file__).parent
         data_file = test_dir / "data" / "results.xml"
         with io.open(str(data_file), mode="br") as input:
-            reader = results.ResultsReader(input)
-            self.assertFalse(reader.is_preview)
-            N_results = 0
-            N_messages = 0
-            for r in reader:
-                from collections import OrderedDict
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
 
-                self.assertTrue(
-                    isinstance(r, OrderedDict) or isinstance(r, results.Message)
-                )
-                if isinstance(r, OrderedDict):
-                    N_results += 1
-                elif isinstance(r, results.Message):
-                    N_messages += 1
-            self.assertEqual(N_results, 4999)
-            self.assertEqual(N_messages, 2)
+                reader = results.ResultsReader(input)
+                self.assertFalse(reader.is_preview)
+                N_results = 0
+                N_messages = 0
+                for r in reader:
+                    from collections import OrderedDict
+
+                    self.assertTrue(
+                        isinstance(r, OrderedDict) or isinstance(r, results.Message)
+                    )
+                    if isinstance(r, OrderedDict):
+                        N_results += 1
+                    elif isinstance(r, results.Message):
+                        N_messages += 1
+                self.assertEqual(N_results, 4999)
+                self.assertEqual(N_messages, 2)
 
     def test_results_reader_with_streaming_results(self):
         # Run jobs.export("search index=_internal | stats count",
@@ -470,21 +474,24 @@ class TestResultsReader(unittest.TestCase):
         test_dir = Path(__file__).parent
         data_file = test_dir / "data" / "streaming_results.xml"
         with io.open(str(data_file), "br") as input:
-            reader = results.ResultsReader(input)
-            N_results = 0
-            N_messages = 0
-            for r in reader:
-                from collections import OrderedDict
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
 
-                self.assertTrue(
-                    isinstance(r, OrderedDict) or isinstance(r, results.Message)
-                )
-                if isinstance(r, OrderedDict):
-                    N_results += 1
-                elif isinstance(r, results.Message):
-                    N_messages += 1
-            self.assertEqual(N_results, 3)
-            self.assertEqual(N_messages, 3)
+                reader = results.ResultsReader(input)
+                N_results = 0
+                N_messages = 0
+                for r in reader:
+                    from collections import OrderedDict
+
+                    self.assertTrue(
+                        isinstance(r, OrderedDict) or isinstance(r, results.Message)
+                    )
+                    if isinstance(r, OrderedDict):
+                        N_results += 1
+                    elif isinstance(r, results.Message):
+                        N_messages += 1
+                self.assertEqual(N_results, 3)
+                self.assertEqual(N_messages, 3)
 
     def test_xmldtd_filter(self):
         s = results._XMLDTDFilter(

--- a/tests/integration/test_results.py
+++ b/tests/integration/test_results.py
@@ -20,6 +20,7 @@ from io import BytesIO
 from time import sleep
 from tests import testlib
 from splunklib import results
+import warnings
 
 
 class ResultsTestCase(testlib.SDKTestCase):
@@ -169,9 +170,11 @@ class ResultsTestCase(testlib.SDKTestCase):
         self.assert_parsed_results_equals(xml_text, expected_results)
 
     def assert_parsed_results_equals(self, xml_text, expected_results):
-        results_reader = results.ResultsReader(BytesIO(xml_text.encode("utf-8")))
-        actual_results = list(results_reader)
-        self.assertEqual(expected_results, actual_results)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            results_reader = results.ResultsReader(BytesIO(xml_text.encode("utf-8")))
+            actual_results = list(results_reader)
+            self.assertEqual(expected_results, actual_results)
 
 
 if __name__ == "__main__":

--- a/tests/unit/searchcommands/test_decorators.py
+++ b/tests/unit/searchcommands/test_decorators.py
@@ -31,7 +31,7 @@ from tests.unit.searchcommands import rebase_environment
 
 
 @Configuration()
-class TestSearchCommand(SearchCommand):
+class SearchCommandForTests(SearchCommand):
     boolean = Option(
         doc="""
         **Syntax:** **boolean=***<value>*
@@ -399,7 +399,7 @@ class TestDecorators(TestCase):
             'show_configuration="f"',
         ]
 
-        command = TestSearchCommand()
+        command = SearchCommandForTests()
         options = command.options
 
         options.reset()

--- a/tests/unit/searchcommands/test_internals_v2.py
+++ b/tests/unit/searchcommands/test_internals_v2.py
@@ -19,6 +19,7 @@ import json
 import os
 import random
 import sys
+import warnings
 
 import pytest
 from sys import float_info
@@ -185,10 +186,14 @@ class TestInternals(TestCase):
             writer.write_metric(name, metric)
 
         self.assertEqual(writer._chunk_count, 0)
-        self.assertEqual(writer._record_count, 31)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PendingDeprecationWarning)
+            self.assertEqual(writer._total_record_count, 0)
+            self.assertEqual(writer._record_count, 31)
+
         self.assertEqual(writer.pending_record_count, 31)
         self.assertGreater(writer._buffer.tell(), 0)
-        self.assertEqual(writer._total_record_count, 0)
         self.assertEqual(writer.committed_record_count, 0)
         fieldnames.sort()
         writer._fieldnames.sort()
@@ -204,12 +209,15 @@ class TestInternals(TestCase):
 
         writer.flush(finished=True)
 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PendingDeprecationWarning)
+            self.assertEqual(writer._record_count, 0)
+            self.assertEqual(writer._total_record_count, 31)
+
         self.assertEqual(writer._chunk_count, 1)
-        self.assertEqual(writer._record_count, 0)
         self.assertEqual(writer.pending_record_count, 0)
         self.assertEqual(writer._buffer.tell(), 0)
         self.assertEqual(writer._buffer.getvalue(), "")
-        self.assertEqual(writer._total_record_count, 31)
         self.assertEqual(writer.committed_record_count, 31)
 
         self.assertRaises(AssertionError, writer.flush, finished=True, partial=True)

--- a/tests/unit/searchcommands/test_search_command.py
+++ b/tests/unit/searchcommands/test_search_command.py
@@ -20,6 +20,7 @@ from unittest import main, TestCase
 
 import os
 import logging
+import warnings
 
 from io import TextIOWrapper
 
@@ -49,7 +50,7 @@ def build_command_input(getinfo_metadata, execute_metadata, execute_body):
 
 
 @Configuration()
-class TestCommand(SearchCommand):
+class CommandForTests(SearchCommand):
     required_option_1 = Option(require=True)
     required_option_2 = Option(require=True)
 
@@ -160,7 +161,7 @@ class TestSearchCommand(TestCase):
 
         ifile = build_command_input(getinfo_metadata, execute_metadata, execute_body)
 
-        command = TestCommand()
+        command = CommandForTests()
         result = BytesIO()
         argv = ["some-external-search-command.py"]
 
@@ -184,8 +185,8 @@ class TestSearchCommand(TestCase):
         self.assertEqual(command.required_option_2, "value_2")
 
         expected = (
-            "chunked 1.0,68,0\n"
-            '{"inspector":{"messages":[["INFO","test command configuration: "]]}}'
+            "chunked 1.0,79,0\n"
+            '{"inspector":{"messages":[["INFO","commandfortests command configuration: "]]}}'
             "chunked 1.0,17,32\n"
             '{"finished":true}test,__mv_test\r\n'
             "data,\r\n"
@@ -206,7 +207,10 @@ class TestSearchCommand(TestCase):
         self.assertEqual([], command.fieldnames)
 
         command_metadata = command.metadata
-        input_header = command.input_header
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            input_header = command.input_header
 
         self.assertIsNone(input_header["allowStream"])
         self.assertEqual(


### PR DESCRIPTION
For the vast majority of warnings, I have simply added a skip, since we cannot remove tests for deprecated APIs.
See: https://docs.python.org/3.6/library/warnings.html#temporarily-suppressing-warnings

Additionally, to eliminate warnings caused by invalid test classes, I renamed two classes to avoid using the “TestNAME” pattern, as such names are automatically recognized as test classes.