### PR TITLE
Don't specify Host header explicitly

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1559,7 +1559,6 @@ def handler(key_file=None, cert_file=None, timeout=None, verify=False, context=N
         body = message.get("body", "")
         head = {
             "Content-Length": str(len(body)),
-            "Host": host,
             "User-Agent": "splunk-sdk-python/%s" % __version__,
             "Accept": "*/*",
             "Connection": "Close",


### PR DESCRIPTION
Just let the http lib handle that for us, we shouldn't be doing that here at all.

Currently we are not handling punycode (if used) and ports, this way we don't have to care about this and just let the lib do the best thing.