### PR TITLE
Add patch and put methods to the service

### DIFF
--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -864,6 +864,158 @@ class Context:
 
     @_authentication
     @_log_duration
+    def put(
+        self,
+        path_segment,
+        owner=None,
+        app=None,
+        sharing=None,
+        headers=None,
+        **query,
+    ):
+        """Performs a PUT operation from the REST path segment with the given object,
+        namespace and query.
+
+        This method is named to match the HTTP method. ``put`` makes at least
+        one round trip to the server, one additional round trip for each 303
+        status returned, and at most two additional round trips if
+        the ``autologin`` field of :func:`connect` is set to ``True``.
+
+        If *owner*, *app*, and *sharing* are omitted, this method uses the
+        default :class:`Context` namespace. All other keyword arguments are
+        included in the URL as query parameters.
+
+        If you provide a ``body`` argument to ``put``, it will be used as the PUT body,
+        and all other keyword arguments will be passed as GET-style arguments in the URL.
+
+        :raises AuthenticationError: Raised when the ``Context`` object is not
+             logged in.
+        :raises HTTPError: Raised when an error occurred in a PUT operation from
+             *path_segment*.
+        :param path_segment: A REST path segment.
+        :type path_segment: ``string``
+        :param owner: The owner context of the namespace (optional).
+        :type owner: ``string``
+        :param app: The app context of the namespace (optional).
+        :type app: ``string``
+        :param sharing: The sharing mode of the namespace (optional).
+        :type sharing: ``string``
+        :param headers: List of extra HTTP headers to send (optional).
+        :type headers: ``list`` of 2-tuples.
+        :param query: All other keyword arguments, which are used as query
+            parameters.
+        :param body: Parameters to be used in the put body. If specified,
+            any parameters in the query will be applied to the URL instead of
+            the body. If a dict is supplied, the key-value pairs will be form
+            encoded. If a string is supplied, the body will be passed through
+            in the request unchanged.
+        :type body: ``dict`` or ``str``
+        :return: The response from the server.
+        :rtype: ``dict`` with keys ``body``, ``headers``, ``reason``,
+                and ``status``
+
+        **Example**::
+
+            c = binding.connect(...)
+            # Call an HTTP endpoint, exposed as Custom Rest Endpoint in a Splunk App.
+            # PUT /servicesNS/-/app_name/custom_rest_endpoint
+            c.put(
+                 app="app_name",
+                 path_segment="custom_rest_endpoint",
+                 body=json.dumps({"key": "val"}),
+                 headers=[("Content-Type", "application/json")],
+            )
+        """
+        if headers is None:
+            headers = []
+
+        path = self.authority + self._abspath(
+            path_segment, owner=owner, app=app, sharing=sharing
+        )
+
+        logger.debug("PUT request to %s (body: %s)", path, mask_sensitive_data(query))
+        all_headers = headers + self.additional_headers + self._auth_headers
+        response = self.http.put(path, all_headers, **query)
+        return response
+
+    @_authentication
+    @_log_duration
+    def patch(
+        self,
+        path_segment,
+        owner=None,
+        app=None,
+        sharing=None,
+        headers=None,
+        **query,
+    ):
+        """Performs a PATCH operation from the REST path segment with the given object,
+        namespace and query.
+
+        This method is named to match the HTTP method. ``patch`` makes at least
+        one round trip to the server, one additional round trip for each 303
+        status returned, and at most two additional round trips if
+        the ``autologin`` field of :func:`connect` is set to ``True``.
+
+        If *owner*, *app*, and *sharing* are omitted, this method uses the
+        default :class:`Context` namespace. All other keyword arguments are
+        included in the URL as query parameters.
+
+        If you provide a ``body`` argument to ``patch``, it will be used as the PATCH body,
+        and all other keyword arguments will be passed as GET-style arguments in the URL.
+
+        :raises AuthenticationError: Raised when the ``Context`` object is not
+             logged in.
+        :raises HTTPError: Raised when an error occurred in a PATCH operation from
+             *path_segment*.
+        :param path_segment: A REST path segment.
+        :type path_segment: ``string``
+        :param owner: The owner context of the namespace (optional).
+        :type owner: ``string``
+        :param app: The app context of the namespace (optional).
+        :type app: ``string``
+        :param sharing: The sharing mode of the namespace (optional).
+        :type sharing: ``string``
+        :param headers: List of extra HTTP headers to send (optional).
+        :type headers: ``list`` of 2-tuples.
+        :param query: All other keyword arguments, which are used as query
+            parameters.
+        :param body: Parameters to be used in the patch body. If specified,
+            any parameters in the query will be applied to the URL instead of
+            the body. If a dict is supplied, the key-value pairs will be form
+            encoded. If a string is supplied, the body will be passed through
+            in the request unchanged.
+        :type body: ``dict`` or ``str``
+        :return: The response from the server.
+        :rtype: ``dict`` with keys ``body``, ``headers``, ``reason``,
+                and ``status``
+
+        **Example**::
+
+            c = binding.connect(...)
+            # Call an HTTP endpoint, exposed as Custom Rest Endpoint in a Splunk App.
+            # PATCH /servicesNS/-/app_name/custom_rest_endpoint
+            c.patch(
+                 app="app_name",
+                 path_segment="custom_rest_endpoint",
+                 body=json.dumps({"key": "val"}),
+                 headers=[("Content-Type", "application/json")],
+            )
+        """
+        if headers is None:
+            headers = []
+
+        path = self.authority + self._abspath(
+            path_segment, owner=owner, app=app, sharing=sharing
+        )
+
+        logger.debug("PATCH request to %s (body: %s)", path, mask_sensitive_data(query))
+        all_headers = headers + self.additional_headers + self._auth_headers
+        response = self.http.patch(path, all_headers, **query)
+        return response
+
+    @_authentication
+    @_log_duration
     def request(
         self,
         path_segment,
@@ -1305,6 +1457,40 @@ class HttpLib:
         self.retries = retries
         self.retryDelay = retryDelay
 
+    def _prepare_request_body_and_url(self, url, headers, **kwargs):
+        """Helper function to prepare the request body and URL.
+
+        :param url: The URL.
+        :type url: ``string``
+        :param headers: A list of pairs specifying the headers for the HTTP request.
+        :type headers: ``list``
+        :param kwargs: Additional keyword arguments (optional).
+        :type kwargs: ``dict``
+        :returns: A tuple containing the updated URL, headers, and body.
+        :rtype: ``tuple``
+        """
+        if headers is None:
+            headers = []
+
+        # We handle GET-style arguments and an unstructured body. This is here
+        # to support the receivers/stream endpoint.
+        if "body" in kwargs:
+            # We only use application/x-www-form-urlencoded if there is no other
+            # Content-Type header present. This can happen in cases where we
+            # send requests as application/json, e.g. for KV Store.
+            if len([x for x in headers if x[0].lower() == "content-type"]) == 0:
+                headers.append(("Content-Type", "application/x-www-form-urlencoded"))
+
+            body = kwargs.pop("body")
+            if isinstance(body, dict):
+                body = _encode(**body).encode("utf-8")
+            if len(kwargs) > 0:
+                url = url + UrlEncoded("?" + _encode(**kwargs), skip_encode=True)
+        else:
+            body = _encode(**kwargs).encode("utf-8")
+
+        return url, headers, body
+
     def delete(self, url, headers=None, **kwargs):
         """Sends a DELETE request to a URL.
 
@@ -1379,26 +1565,52 @@ class HttpLib:
             its structure).
         :rtype: ``dict``
         """
-        if headers is None:
-            headers = []
-
-        # We handle GET-style arguments and an unstructured body. This is here
-        # to support the receivers/stream endpoint.
-        if "body" in kwargs:
-            # We only use application/x-www-form-urlencoded if there is no other
-            # Content-Type header present. This can happen in cases where we
-            # send requests as application/json, e.g. for KV Store.
-            if len([x for x in headers if x[0].lower() == "content-type"]) == 0:
-                headers.append(("Content-Type", "application/x-www-form-urlencoded"))
-
-            body = kwargs.pop("body")
-            if isinstance(body, dict):
-                body = _encode(**body).encode("utf-8")
-            if len(kwargs) > 0:
-                url = url + UrlEncoded("?" + _encode(**kwargs), skip_encode=True)
-        else:
-            body = _encode(**kwargs).encode("utf-8")
+        url, headers, body = self._prepare_request_body_and_url(url, headers, **kwargs)
         message = {"method": "POST", "headers": headers, "body": body}
+        return self.request(url, message)
+
+    def put(self, url, headers=None, **kwargs):
+        """Sends a PUT request to a URL.
+
+        :param url: The URL.
+        :type url: ``string``
+        :param headers: A list of pairs specifying the headers for the HTTP
+            response (for example, ``[('Content-Type': 'text/cthulhu'), ('Token': 'boris')]``).
+        :type headers: ``list``
+        :param kwargs: Additional keyword arguments (optional). If the argument
+            is ``body``, the value is used as the body for the request, and the
+            keywords and their arguments will be URL encoded. If there is no
+            ``body`` keyword argument, all the keyword arguments are encoded
+            into the body of the request in the format ``x-www-form-urlencoded``.
+        :type kwargs: ``dict``
+        :returns: A dictionary describing the response (see :class:`HttpLib` for
+            its structure).
+        :rtype: ``dict``
+        """
+        url, headers, body = self._prepare_request_body_and_url(url, headers, **kwargs)
+        message = {"method": "PUT", "headers": headers, "body": body}
+        return self.request(url, message)
+
+    def patch(self, url, headers=None, **kwargs):
+        """Sends a PATCH request to a URL.
+
+        :param url: The URL.
+        :type url: ``string``
+        :param headers: A list of pairs specifying the headers for the HTTP
+            response (for example, ``[('Content-Type': 'text/cthulhu'), ('Token': 'boris')]``).
+        :type headers: ``list``
+        :param kwargs: Additional keyword arguments (optional). If the argument
+            is ``body``, the value is used as the body for the request, and the
+            keywords and their arguments will be URL encoded. If there is no
+            ``body`` keyword argument, all the keyword arguments are encoded
+            into the body of the request in the format ``x-www-form-urlencoded``.
+        :type kwargs: ``dict``
+        :returns: A dictionary describing the response (see :class:`HttpLib` for
+            its structure).
+        :rtype: ``dict``
+        """
+        url, headers, body = self._prepare_request_body_and_url(url, headers, **kwargs)
+        message = {"method": "PATCH", "headers": headers, "body": body}
         return self.request(url, message)
 
     def request(self, url, message, **kwargs):

--- a/tests/integration/test_binding.py
+++ b/tests/integration/test_binding.py
@@ -937,7 +937,31 @@ class TestPostWithBodyParam(unittest.TestCase):
             body={"testkey": "testvalue"},
         )
 
-    def test_post_with_params_and_no_body(self):
+    def test_post_with_params_and_body_json(self):
+        def handler(url, message, **kwargs):
+            assert (
+                url
+                == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar?extrakey=extraval"
+            )
+            assert message["body"] == '{"testkey": "testvalue"}'
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.post(
+            "foo/bar",
+            extrakey="extraval",
+            owner="testowner",
+            app="testapp",
+            body=json.dumps({"testkey": "testvalue"}),
+            headers=[("Content-Type", "application/json")],
+        )
+
+    def test_post_with_urlencoded_params(self):
         def handler(url, message, **kwargs):
             assert url == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar"
             assert message["body"] == b"extrakey=extraval"
@@ -950,6 +974,164 @@ class TestPostWithBodyParam(unittest.TestCase):
 
         ctx = binding.Context(handler=handler)
         ctx.post("foo/bar", extrakey="extraval", owner="testowner", app="testapp")
+
+
+class TestPutWithBodyParam(unittest.TestCase):
+    def test_put(self):
+        def handler(url, message, **kwargs):
+            assert url == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar"
+            assert message["body"] == b"testkey=testvalue"
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.put(
+            "foo/bar", owner="testowner", app="testapp", body={"testkey": "testvalue"}
+        )
+
+    def test_put_with_params_and_body_form(self):
+        def handler(url, message, **kwargs):
+            assert (
+                url
+                == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar?extrakey=extraval"
+            )
+            assert message["body"] == b"testkey=testvalue"
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.put(
+            "foo/bar",
+            extrakey="extraval",
+            owner="testowner",
+            app="testapp",
+            body={"testkey": "testvalue"},
+        )
+
+    def test_put_with_params_and_body_json(self):
+        def handler(url, message, **kwargs):
+            assert (
+                url
+                == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar?extrakey=extraval"
+            )
+            assert message["body"] == '{"testkey": "testvalue"}'
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.put(
+            "foo/bar",
+            extrakey="extraval",
+            owner="testowner",
+            app="testapp",
+            body=json.dumps({"testkey": "testvalue"}),
+            headers=[("Content-Type", "application/json")],
+        )
+
+    def test_put_with_urlencoded_params(self):
+        def handler(url, message, **kwargs):
+            assert url == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar"
+            assert message["body"] == b"extrakey=extraval"
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.put("foo/bar", extrakey="extraval", owner="testowner", app="testapp")
+
+
+class TestPatchWithBodyParam(unittest.TestCase):
+    def test_patch(self):
+        def handler(url, message, **kwargs):
+            assert url == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar"
+            assert message["body"] == b"testkey=testvalue"
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.patch(
+            "foo/bar", owner="testowner", app="testapp", body={"testkey": "testvalue"}
+        )
+
+    def test_patch_with_params_and_body_form(self):
+        def handler(url, message, **kwargs):
+            assert (
+                url
+                == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar?extrakey=extraval"
+            )
+            assert message["body"] == b"testkey=testvalue"
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.patch(
+            "foo/bar",
+            extrakey="extraval",
+            owner="testowner",
+            app="testapp",
+            body={"testkey": "testvalue"},
+        )
+
+    def test_patch_with_params_and_body_json(self):
+        def handler(url, message, **kwargs):
+            assert (
+                url
+                == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar?extrakey=extraval"
+            )
+            assert message["body"] == '{"testkey": "testvalue"}'
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.patch(
+            "foo/bar",
+            extrakey="extraval",
+            owner="testowner",
+            app="testapp",
+            body=json.dumps({"testkey": "testvalue"}),
+            headers=[("Content-Type", "application/json")],
+        )
+
+    def test_patch_with_urlencoded_params(self):
+        def handler(url, message, **kwargs):
+            assert url == "https://localhost:8089/servicesNS/testowner/testapp/foo/bar"
+            assert message["body"] == b"extrakey=extraval"
+            return splunklib.data.Record(
+                {
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+
+        ctx = binding.Context(handler=handler)
+        ctx.patch("foo/bar", extrakey="extraval", owner="testowner", app="testapp")
 
 
 def _wrap_handler(func, response_code=200, body=""):
@@ -1036,6 +1218,88 @@ class TestFullPost(unittest.TestCase):
         with MockServer(POST=check_response):
             ctx = binding.connect(port=9093, scheme="http", token="waffle")
             ctx.post("/", foo="bar", body={"baz": "baf", "hep": "cat"})
+
+
+class TestFullPut(unittest.TestCase):
+    def test_put_with_body_urlencoded(self):
+        def check_response(handler):
+            length = int(handler.headers.get("content-length", 0))
+            body = handler.rfile.read(length)
+            assert body.decode("utf-8") == "foo=bar"
+
+        with MockServer(PUT=check_response):
+            ctx = binding.connect(port=9093, scheme="http", token="waffle")
+            ctx.put("/", foo="bar")
+
+    def test_put_with_body_string(self):
+        def check_response(handler):
+            length = int(handler.headers.get("content-length", 0))
+            body = handler.rfile.read(length)
+            assert handler.headers["content-type"] == "application/json"
+            assert json.loads(body)["baz"] == "baf"
+
+        with MockServer(PUT=check_response):
+            ctx = binding.connect(
+                port=9093,
+                scheme="http",
+                token="waffle",
+                headers=[("Content-Type", "application/json")],
+            )
+            ctx.put("/", foo="bar", body='{"baz": "baf"}')
+
+    def test_put_with_body_dict(self):
+        def check_response(handler):
+            length = int(handler.headers.get("content-length", 0))
+            body = handler.rfile.read(length)
+            assert (
+                handler.headers["content-type"] == "application/x-www-form-urlencoded"
+            )
+            assert ensure_str(body) in ["baz=baf&hep=cat", "hep=cat&baz=baf"]
+
+        with MockServer(PUT=check_response):
+            ctx = binding.connect(port=9093, scheme="http", token="waffle")
+            ctx.put("/", foo="bar", body={"baz": "baf", "hep": "cat"})
+
+
+class TestFullPatch(unittest.TestCase):
+    def test_patch_with_body_urlencoded(self):
+        def check_response(handler):
+            length = int(handler.headers.get("content-length", 0))
+            body = handler.rfile.read(length)
+            assert body.decode("utf-8") == "foo=bar"
+
+        with MockServer(PATCH=check_response):
+            ctx = binding.connect(port=9093, scheme="http", token="waffle")
+            ctx.patch("/", foo="bar")
+
+    def test_patch_with_body_string(self):
+        def check_response(handler):
+            length = int(handler.headers.get("content-length", 0))
+            body = handler.rfile.read(length)
+            assert handler.headers["content-type"] == "application/json"
+            assert json.loads(body)["baz"] == "baf"
+
+        with MockServer(PATCH=check_response):
+            ctx = binding.connect(
+                port=9093,
+                scheme="http",
+                token="waffle",
+                headers=[("Content-Type", "application/json")],
+            )
+            ctx.patch("/", foo="bar", body='{"baz": "baf"}')
+
+    def test_patch_with_body_dict(self):
+        def check_response(handler):
+            length = int(handler.headers.get("content-length", 0))
+            body = handler.rfile.read(length)
+            assert (
+                handler.headers["content-type"] == "application/x-www-form-urlencoded"
+            )
+            assert ensure_str(body) in ["baz=baf&hep=cat", "hep=cat&baz=baf"]
+
+        with MockServer(PATCH=check_response):
+            ctx = binding.connect(port=9093, scheme="http", token="waffle")
+            ctx.patch("/", foo="bar", body={"baz": "baf", "hep": "cat"})
 
 
 if __name__ == "__main__":

--- a/tests/system/test_cre_apps.py
+++ b/tests/system/test_cre_apps.py
@@ -15,10 +15,8 @@
 # under the License.
 
 import json
-import pytest
 
 from tests import testlib
-from splunklib import results
 
 
 class TestJSONCustomRestEndpointsSpecialMethodHelpers(testlib.SDKTestCase):
@@ -56,6 +54,47 @@ class TestJSONCustomRestEndpointsSpecialMethodHelpers(testlib.SDKTestCase):
                 "payload": '{"foo": "bar"}',
                 "headers": {"x-bar": "baz"},
                 "method": "POST",
+            },
+        )
+
+    def test_PUT(self):
+        body = json.dumps({"foo": "bar"})
+        resp = self.service.put(
+            app=self.app_name,
+            path_segment="execute",
+            body=body,
+            headers=[("x-bar", "baz")],
+        )
+        self.assertIn(("x-foo", "bar"), resp.headers)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(
+            json.loads(str(resp.body)),
+            {
+                "payload": '{"foo": "bar"}',
+                "headers": {"x-bar": "baz"},
+                "method": "PUT",
+            },
+        )
+
+    def test_PATCH(self):
+        if self.service.splunk_version[0] < 10:
+            self.skipTest("PATCH custom REST endpoints not supported on splunk < 10")
+
+        body = json.dumps({"foo": "bar"})
+        resp = self.service.patch(
+            app=self.app_name,
+            path_segment="execute",
+            body=body,
+            headers=[("x-bar", "baz")],
+        )
+        self.assertIn(("x-foo", "bar"), resp.headers)
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(
+            json.loads(str(resp.body)),
+            {
+                "payload": '{"foo": "bar"}',
+                "headers": {"x-bar": "baz"},
+                "method": "PATCH",
             },
         )
 


### PR DESCRIPTION
Solves review comments of #586, additionally removes the `object` parameter, for consistency with DELETE.

Closes #586
Fixes #577