### PR TITLE
Adjust top-level comments in all files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Splunk SDK for Python documentation build configuration file, created by
 # sphinx-quickstart on Fri Apr 13 12:28:15 2012.
 #

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/__init__.py
+++ b/splunklib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/binding.py
+++ b/splunklib/binding.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/client.py
+++ b/splunklib/client.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/data.py
+++ b/splunklib/data.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/argument.py
+++ b/splunklib/modularinput/argument.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/event.py
+++ b/splunklib/modularinput/event.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/event_writer.py
+++ b/splunklib/modularinput/event_writer.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/input_definition.py
+++ b/splunklib/modularinput/input_definition.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/scheme.py
+++ b/splunklib/modularinput/scheme.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/script.py
+++ b/splunklib/modularinput/script.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/utils.py
+++ b/splunklib/modularinput/utils.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/modularinput/validation_definition.py
+++ b/splunklib/modularinput/validation_definition.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/results.py
+++ b/splunklib/results.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/__init__.py
+++ b/splunklib/searchcommands/__init__.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/decorators.py
+++ b/splunklib/searchcommands/decorators.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/environment.py
+++ b/splunklib/searchcommands/environment.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/eventing_command.py
+++ b/splunklib/searchcommands/eventing_command.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/external_search_command.py
+++ b/splunklib/searchcommands/external_search_command.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/generating_command.py
+++ b/splunklib/searchcommands/generating_command.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/reporting_command.py
+++ b/splunklib/searchcommands/reporting_command.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/search_command.py
+++ b/splunklib/searchcommands/search_command.py
@@ -1228,8 +1228,8 @@ def dispatch(
     ..  code-block:: python
         :linenos:
 
-        #!/usr/bin/env python
         from splunklib.searchcommands import dispatch, StreamingCommand, Configuration, Option, validators
+        
         @Configuration()
         class SomeStreamingCommand(StreamingCommand):
             ...

--- a/splunklib/searchcommands/streaming_command.py
+++ b/splunklib/searchcommands/streaming_command.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/searchcommands/validators.py
+++ b/splunklib/searchcommands/validators.py
@@ -1,6 +1,4 @@
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/splunklib/utils.py
+++ b/splunklib/utils.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_binding.py
+++ b/tests/integration/test_binding.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_collection.py
+++ b/tests/integration/test_collection.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_conf.py
+++ b/tests/integration/test_conf.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_event_type.py
+++ b/tests/integration/test_event_type.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_fired_alert.py
+++ b/tests/integration/test_fired_alert.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_input.py
+++ b/tests/integration/test_input.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_job.py
+++ b/tests/integration/test_job.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_kvstore_batch.py
+++ b/tests/integration/test_kvstore_batch.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_kvstore_conf.py
+++ b/tests/integration/test_kvstore_conf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2011-2020 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_kvstore_conf.py
+++ b/tests/integration/test_kvstore_conf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may

--- a/tests/integration/test_kvstore_data.py
+++ b/tests/integration/test_kvstore_data.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_logger.py
+++ b/tests/integration/test_logger.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_macro.py
+++ b/tests/integration/test_macro.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright 2011-2015 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_message.py
+++ b/tests/integration/test_message.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_modular_input_kinds.py
+++ b/tests/integration/test_modular_input_kinds.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_role.py
+++ b/tests/integration/test_role.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_saved_search.py
+++ b/tests/integration/test_saved_search.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_storage_passwords.py
+++ b/tests/integration/test_storage_passwords.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/integration/test_user.py
+++ b/tests/integration/test_user.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_apps/eventing_app/bin/eventingcsc.py
+++ b/tests/system/test_apps/eventing_app/bin/eventingcsc.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_apps/generating_app/bin/generatingcsc.py
+++ b/tests/system/test_apps/generating_app/bin/generatingcsc.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_apps/modularinput_app/bin/modularinput.py
+++ b/tests/system/test_apps/modularinput_app/bin/modularinput.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-# Copyright © 2011-2025 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_apps/reporting_app/bin/reportingcsc.py
+++ b/tests/system/test_apps/reporting_app/bin/reportingcsc.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_apps/streaming_app/bin/streamingcsc.py
+++ b/tests/system/test_apps/streaming_app/bin/streamingcsc.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_cre_apps.py
+++ b/tests/system/test_cre_apps.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2025 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_csc_apps.py
+++ b/tests/system/test_csc_apps.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/system/test_modularinput_app.py
+++ b/tests/system/test_modularinput_app.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2025 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/modularinput/modularinput_testlib.py
+++ b/tests/unit/modularinput/modularinput_testlib.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/modularinput/test_event.py
+++ b/tests/unit/modularinput/test_event.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/modularinput/test_input_definition.py
+++ b/tests/unit/modularinput/test_input_definition.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/modularinput/test_scheme.py
+++ b/tests/unit/modularinput/test_scheme.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/modularinput/test_validation_definition.py
+++ b/tests/unit/modularinput/test_validation_definition.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/__init__.py
+++ b/tests/unit/searchcommands/__init__.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_builtin_options.py
+++ b/tests/unit/searchcommands/test_builtin_options.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_configuration_settings.py
+++ b/tests/unit/searchcommands/test_configuration_settings.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_decorators.py
+++ b/tests/unit/searchcommands/test_decorators.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_internals_v1.py
+++ b/tests/unit/searchcommands/test_internals_v1.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_internals_v2.py
+++ b/tests/unit/searchcommands/test_internals_v2.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_search_command.py
+++ b/tests/unit/searchcommands/test_search_command.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/searchcommands/test_validators.py
+++ b/tests/unit/searchcommands/test_validators.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# coding=utf-8
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-#
-# Copyright © 2011-2025 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain

--- a/utils/cmdopts.py
+++ b/utils/cmdopts.py
@@ -1,4 +1,4 @@
-# Copyright © 2011-2024 Splunk, Inc.
+# Copyright © 2011-2026 Splunk, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"): you may
 # not use this file except in compliance with the License. You may obtain


### PR DESCRIPTION
- Adjusted copyright dates
- Removed obsolete [# coding=utf8](https://peps.python.org/pep-0263/) statements (it's been a long time since Python started treating all files as UTF-8)
- Removed shebangs