### PR TITLE
Fix test_list_with_sort_dir

### DIFF
--- a/tests/integration/test_collection.py
+++ b/tests/integration/test_collection.py
@@ -158,11 +158,11 @@ class CollectionTestCase(testlib.SDKTestCase):
                 expected_kwargs["sort_key"] = "sid"
                 found_kwargs["sort_key"] = "sid"
             expected = list(
-                reversed([ent.name for ent in coll.list(**expected_kwargs)])
+                reversed([ent.name.lower() for ent in coll.list(**expected_kwargs)])
             )
             if len(expected) == 0:
                 logging.debug(f"No entities in collection {coll_name}; skipping test.")
-            found = [ent.name for ent in coll.list(**found_kwargs)]
+            found = [ent.name.lower() for ent in coll.list(**found_kwargs)]
 
             if expected != found:
                 logging.warning(


### PR DESCRIPTION
Splunk orders these case insensitively, thus we have to lower these before doing a compare.