### PR TITLE
Improve handling `AIMessage.content`

### DIFF
--- a/examples/ai_modinput_app/bin/agentic_weather.py
+++ b/examples/ai_modinput_app/bin/agentic_weather.py
@@ -20,6 +20,8 @@ import sys
 from _collections_abc import dict_items
 from typing import final, override
 
+from splunklib.ai.messages import AIMessage, ContentBlock, TextBlock
+
 # ! NOTE: This insert is only needed for splunk-sdk-python CI/CD to work.
 # ! Remove this if you're modifying this example locally.
 sys.path.insert(0, "/splunklib-deps")
@@ -95,9 +97,9 @@ class AgenticWeatherModInput(Script):
                     weather_events += list(reader)
 
                 for weather_event in weather_events:
-                    weather_event["human_readable"] = asyncio.run(
-                        self.invoke_agent(weather_event)
-                    )
+                    result = asyncio.run(self.invoke_agent(weather_event))
+                    weather_event["human_readable"] = self.parse_content(result)
+
                     logger.debug(f"{weather_event=}")
 
                     event = Event(
@@ -112,7 +114,7 @@ class AgenticWeatherModInput(Script):
 
             logger.debug(f"Finishing enrichment for {input_name} at {csv_file_path}")
 
-    async def invoke_agent(self, weather_event: dict[str, str | int]) -> str:
+    async def invoke_agent(self, weather_event: dict[str, str | int]) -> AIMessage:
         if not self.service:
             raise AssertionError("No Splunk connection available")
 
@@ -127,7 +129,27 @@ class AgenticWeatherModInput(Script):
                 data=weather_event,
             )
             logger.debug(f"{response=}")
-            return response.final_message.content
+            return response.final_message
+
+    def _parse_content_block(self, block: str | ContentBlock) -> str | None:
+        match block:
+            case TextBlock():
+                return block.text
+            case str():
+                return block
+            case _:
+                return None
+
+    def parse_content(self, message: AIMessage) -> str:
+        """Parses the content from AIMessage and builds a single string our of it"""
+        if isinstance(message.content, str):
+            return message.content
+
+        return " ".join(
+            parsed_block
+            for block in message.content
+            if (parsed_block := self._parse_content_block(block))
+        )
 
 
 if __name__ == "__main__":

--- a/splunklib/ai/engines/langchain.py
+++ b/splunklib/ai/engines/langchain.py
@@ -77,7 +77,9 @@ from splunklib.ai.messages import (
     AgentResponse,
     AIMessage,
     BaseMessage,
+    ContentBlock,
     HumanMessage,
+    OpaqueBlock,
     OutputT,
     StructuredOutputCall,
     StructuredOutputMessage,
@@ -87,6 +89,7 @@ from splunklib.ai.messages import (
     SubagentStructuredResult,
     SubagentTextResult,
     SystemMessage,
+    TextBlock,
     ToolCall,
     ToolFailureResult,
     ToolMessage,
@@ -955,7 +958,7 @@ class _Middleware(LC_AgentMiddleware):
         return LC_ToolMessage(
             name=_normalize_agent_name(call.name),
             tool_call_id=call.id,
-            content=content,
+            content=_map_content_to_langchain(content),
             status=status,
             artifact=sdk_result,
         )
@@ -1089,7 +1092,10 @@ def _convert_model_response_to_model_result(
     # This invariant is asserted via ModelResponse.__post_init__
     assert len(resp.message.structured_output_calls) <= 1
 
-    lc_message = LC_AIMessage(content=resp.message.content)
+    lc_message = LC_AIMessage(
+        content=_map_content_to_langchain(resp.message.content),
+        additional_kwargs=resp.message.extras or {},
+    )
     # This field can't be set via __init__()
     lc_message.tool_calls = [_map_tool_call_to_langchain(c) for c in resp.message.calls]
 
@@ -1164,7 +1170,7 @@ def _convert_tool_message_to_lc(
         name=name,
         tool_call_id=message.call_id,
         status=status,
-        content=content,
+        content=_map_content_to_langchain(content),
         artifact=artifact,
     )
 
@@ -1247,9 +1253,10 @@ def _convert_model_result_from_lc(model_response: LC_ModelCallResult) -> ModelRe
         ai_message = model_response
         structured_response = None
 
+    additional_kwargs = cast(dict[str, Any], ai_message.additional_kwargs)
     return ModelResponse(
         message=AIMessage(
-            content=ai_message.content.__str__(),
+            content=_map_content_from_langchain(ai_message.content),  # pyright: ignore[reportUnknownArgumentType]
             calls=[
                 _map_tool_call_from_langchain(tc)
                 for tc in ai_message.tool_calls
@@ -1264,6 +1271,7 @@ def _convert_model_result_from_lc(model_response: LC_ModelCallResult) -> ModelRe
                 for tc in ai_message.tool_calls
                 if tc["name"].startswith(TOOL_STRATEGY_TOOL_PREFIX)
             ],
+            extras=additional_kwargs,
         ),
         structured_output=structured_response,
     )
@@ -1426,6 +1434,28 @@ def _is_agent_name_valid(name: str) -> bool:
     return set(name).issubset(AGENT_NAME_ALLOWED_CHARS)
 
 
+def _parse_content_block(block: str | ContentBlock) -> str | None:
+    match block:
+        case TextBlock():
+            return block.text
+        case str():
+            return block
+        case _:
+            return None
+
+
+def _parse_content(content: str | list[str | ContentBlock]) -> str:
+    """Parses the content from AIMessage and builds a single string our of it"""
+    if isinstance(content, str):
+        return content
+
+    return " ".join(
+        parsed_block
+        for block in content
+        if (parsed_block := _parse_content_block(block))
+    )
+
+
 def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
     if not agent.name:
         raise AssertionError("Agent must have a name to be used by other Agents")
@@ -1437,7 +1467,10 @@ def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
 
     async def invoke_agent(
         message: HumanMessage, thread_id: str | None
-    ) -> tuple[OutputT | str, SubagentStructuredResult | SubagentTextResult]:
+    ) -> tuple[
+        OutputT | str,
+        SubagentStructuredResult | SubagentTextResult,
+    ]:
         result = await agent.invoke([message], thread_id=thread_id)
 
         if agent.output_schema:
@@ -1446,9 +1479,8 @@ def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
                 structured_output=result.structured_output.model_dump(),
             )
 
-        return result.final_message.content, SubagentTextResult(
-            content=result.final_message.content
-        )
+        text_content = _parse_content(result.final_message.content)
+        return text_content, SubagentTextResult(content=text_content)
 
     InputSchema = agent.input_schema
     if InputSchema is None:
@@ -1456,13 +1488,19 @@ def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
 
             async def _run(  # pyright: ignore[reportRedeclaration]
                 content: str, thread_id: str
-            ) -> tuple[OutputT | str, SubagentStructuredResult | SubagentTextResult]:
+            ) -> tuple[
+                OutputT | str,
+                SubagentStructuredResult | SubagentTextResult,
+            ]:
                 return await invoke_agent(HumanMessage(content=content), thread_id)
         else:
 
             async def _run(  # pyright: ignore[reportRedeclaration]
                 content: str,
-            ) -> tuple[OutputT | str, SubagentStructuredResult | SubagentTextResult]:
+            ) -> tuple[
+                OutputT | str,
+                SubagentStructuredResult | SubagentTextResult,
+            ]:
                 return await invoke_agent(HumanMessage(content=content), None)
 
         return StructuredTool.from_function(
@@ -1475,7 +1513,10 @@ def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
 
     async def invoke_agent_structured(
         content: BaseModel, thread_id: str | None
-    ) -> tuple[OutputT | str, SubagentStructuredResult | SubagentTextResult]:
+    ) -> tuple[
+        OutputT | str,
+        SubagentStructuredResult | SubagentTextResult,
+    ]:
         result = await agent.invoke_with_data(
             instructions="Follow the system prompt.",
             data=content.model_dump(),
@@ -1488,15 +1529,17 @@ def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
                 structured_output=result.structured_output.model_dump(),
             )
 
-        return result.final_message.content, SubagentTextResult(
-            content=result.final_message.content
-        )
+        text_content = _parse_content(result.final_message.content)
+        return text_content, SubagentTextResult(content=text_content)
 
     if agent.conversation_store:
 
         async def _run(
             **kwargs: Any,  # noqa: ANN401
-        ) -> tuple[OutputT | str, SubagentStructuredResult | SubagentTextResult]:
+        ) -> tuple[
+            OutputT | str,
+            SubagentStructuredResult | SubagentTextResult,
+        ]:
             content: BaseModel = kwargs["content"]
             thread_id: str = kwargs["thread_id"]
             return await invoke_agent_structured(content, thread_id)
@@ -1516,7 +1559,10 @@ def _agent_as_tool(agent: BaseAgent[OutputT]) -> StructuredTool:
 
         async def _run(
             **kwargs: Any,  # noqa: ANN401
-        ) -> tuple[OutputT | str, SubagentStructuredResult | SubagentTextResult]:
+        ) -> tuple[
+            OutputT | str,
+            SubagentStructuredResult | SubagentTextResult,
+        ]:
             content = InputSchema(**kwargs)
             return await invoke_agent_structured(content, None)
 
@@ -1568,11 +1614,69 @@ def _map_tool_call_to_langchain(call: ToolCall | SubagentCall) -> LC_ToolCall:
     return LC_ToolCall(id=call.id, name=name, args=args)
 
 
+def _map_content_from_langchain(
+    content: str | list[str | dict[str, Any]],
+) -> str | list[str | ContentBlock]:
+    if isinstance(content, str):
+        return content
+
+    result_content = [_map_content_block_from_langchain(b) for b in content]
+
+    return result_content
+
+
+def _map_content_block_from_langchain(
+    block: str | dict[str, Any],
+) -> str | ContentBlock:
+    if isinstance(block, str):
+        return block
+
+    match block.get("type"):
+        case "text":
+            return TextBlock(
+                text=block["text"], extras=block.get("extras"), id=block.get("id")
+            )
+        case _:
+            # NOTE: we return data we're not handling
+            # as opaque content blocks so they
+            # are preserved and sent back to the LLM
+            return OpaqueBlock(_data=block)
+
+
+def _map_content_to_langchain(
+    content: str | list[str | ContentBlock],
+) -> str | list[str | dict[str, Any]]:
+    if isinstance(content, str):
+        return content
+
+    result_content = [_map_content_block_to_langchain(b) for b in content]
+
+    return result_content
+
+
+def _map_content_block_to_langchain(block: str | ContentBlock) -> str | dict[str, Any]:
+    if isinstance(block, str):
+        return block
+
+    match block:
+        case TextBlock():
+            result: dict[str, Any] = {
+                "type": "text",
+                "text": block.text,
+                "id": block.id,
+            }
+            if block.extras:
+                result["extras"] = block.extras
+            return result
+        case OpaqueBlock():
+            return block._data  # pyright: ignore[reportPrivateUsage]
+
+
 def _map_message_from_langchain(message: LC_BaseMessage) -> BaseMessage:
     match message:
         case LC_AIMessage():
             return AIMessage(
-                content=message.content.__str__(),
+                content=_map_content_from_langchain(message.content),  # pyright: ignore[reportUnknownArgumentType]
                 calls=[
                     _map_tool_call_from_langchain(tc)
                     for tc in message.tool_calls
@@ -1587,6 +1691,7 @@ def _map_message_from_langchain(message: LC_BaseMessage) -> BaseMessage:
                     for tc in message.tool_calls
                     if tc["name"].startswith(TOOL_STRATEGY_TOOL_PREFIX)
                 ],
+                extras=cast(dict[str, Any], message.additional_kwargs),
             )
         case LC_HumanMessage():
             return HumanMessage(content=message.content.__str__())
@@ -1601,7 +1706,10 @@ def _map_message_from_langchain(message: LC_BaseMessage) -> BaseMessage:
 def _map_message_to_langchain(message: BaseMessage) -> LC_AnyMessage:
     match message:
         case AIMessage():
-            lc_message = LC_AIMessage(content=message.content)
+            lc_message = LC_AIMessage(
+                content=_map_content_to_langchain(message.content),
+                additional_kwargs=message.extras or {},
+            )
             # This field can't be set via constructor
             lc_message.tool_calls = [
                 _map_tool_call_to_langchain(c) for c in message.calls

--- a/splunklib/ai/hooks.py
+++ b/splunklib/ai/hooks.py
@@ -199,5 +199,3 @@ class TimeoutLimitMiddleware(AgentMiddleware):
         if self._deadline is not None and monotonic() >= self._deadline:
             raise TimeoutExceededException(timeout_seconds=self._seconds)
         return await handler(request)
-
-

--- a/splunklib/ai/messages.py
+++ b/splunklib/ai/messages.py
@@ -22,6 +22,47 @@ from splunklib.ai.tools import ToolType
 
 
 @dataclass(frozen=True)
+class TextBlock:
+    """Plain text content block returned by a model."""
+
+    text: str
+    id: str | None = field(default=None)
+    extras: dict[str, Any] | None = field(default=None)
+    """ This field contains LLM-specific metadata.
+
+    It should be returned to the LLM unchanged in subsequent LLM calls.
+    The contents of this field is not guaranteed to be stable
+    and might change as SDK evolves.
+    """
+
+
+@dataclass(frozen=True)
+class OpaqueBlock:
+    """Content block of an unrecognized or unsupported type.
+
+    The raw provider dict is preserved in `_data` so it can be sent back
+    to the model unchanged on subsequent calls.
+    """
+
+    _data: dict[str, Any]
+    """This is raw data coming from the backend library.
+
+    This field is used to preserve the content blocks returned
+    from LLM, but not supported by the SDK.
+
+    DO NOT change the contents of this field.
+
+    If adding logic based around contents of this
+    field, keep in mind things could BREAK in the future,
+    once first class support is added to new content blocks.
+    """
+
+
+# Type alias for all content block variants.
+ContentBlock = TextBlock | OpaqueBlock
+
+
+@dataclass(frozen=True)
 class ToolCall:
     name: str
     args: dict[str, Any]
@@ -85,12 +126,19 @@ class AIMessage(BaseMessage):
     """
 
     role: Literal["assistant"] = field(default="assistant", init=False)
-    content: str
+    content: str | list[str | ContentBlock]
 
     calls: Sequence[ToolCall | SubagentCall]
     structured_output_calls: Sequence[StructuredOutputCall] = field(
         default_factory=tuple
     )
+    extras: dict[str, Any] | None = field(default=None)
+    """ This field contains LLM-specific metadata.
+
+    It should be returned to the LLM unchanged in subsequent LLM calls.
+    The contents of this field is not guaranteed to be stable
+    and might change as SDK evolves.
+    """
 
 
 @dataclass(frozen=True)

--- a/tests/ai_testlib.py
+++ b/tests/ai_testlib.py
@@ -6,11 +6,13 @@ from collections.abc import Callable, Coroutine
 from typing import Any, override
 from unittest.mock import patch
 from urllib import parse
+from warnings import warn
 
 import vcr
 from vcr.config import RecordMode
 from vcr.request import Request
 
+from splunklib.ai.messages import AIMessage, ContentBlock, TextBlock
 from splunklib.ai.model import PredefinedModel
 from tests.ai_test_model import InternalAIModel, TestLLMSettings, create_model
 from tests.testlib import SDKTestCase
@@ -31,6 +33,27 @@ class AITestCase(SDKTestCase):
             if app.name.lower() == "splunk_mcp_server":
                 app.delete()
                 self.restart_splunk()
+
+    def _parse_content_block(self, block: str | ContentBlock) -> str | None:
+        match block:
+            case TextBlock():
+                return block.text
+            case str():
+                return block
+            case _:
+                warn(f"Skipping OpaqueBlock when parsing the AIMessage.content")
+                return None
+
+    def parse_content(self, message: AIMessage) -> str:
+        """Parses the content from AIMessage and builds a single string our of it"""
+        if isinstance(message.content, str):
+            return message.content
+
+        return " ".join(
+            parsed_block
+            for block in message.content
+            if (parsed_block := self._parse_content_block(block))
+        )
 
     @property
     def test_llm_settings(self) -> TestLLMSettings:

--- a/tests/integration/ai/test_agent.py
+++ b/tests/integration/ai/test_agent.py
@@ -65,7 +65,12 @@ class TestAgent(AITestCase):
                 ]
             )
 
-            response = result.final_message.content.strip().lower().replace(".", "")
+            response = (
+                self.parse_content(result.final_message)
+                .strip()
+                .lower()
+                .replace(".", "")
+            )
             assert result.structured_output is None, (
                 "The structured output should not be populated"
             )
@@ -157,7 +162,7 @@ class TestAgent(AITestCase):
 
             response = result.structured_output
 
-            last_message = result.final_message.content
+            last_message = self.parse_content(result.final_message)
 
             assert type(response) == Person, "Response is not of type Person"
             assert response.name != "", "Name field is empty"
@@ -227,7 +232,7 @@ class TestAgent(AITestCase):
             )
             assert subagent_message, "No subagent message found in response"
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris-zilla" in response, "Agent did generate valid nickname"
 
     @pytest.mark.asyncio
@@ -272,7 +277,7 @@ class TestAgent(AITestCase):
             assert first_ai_message.calls[0].args.lower() == "chris"
             assert first_ai_message.calls[0].thread_id is None, "unexpected thread_id"
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris-zilla" in response, "Agent did generate valid nickname"
 
     @pytest.mark.asyncio
@@ -314,7 +319,7 @@ class TestAgent(AITestCase):
                 ]
             )
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris-zilla" in response, "Agent did generate valid nickname"
 
     @pytest.mark.asyncio

--- a/tests/integration/ai/test_agent_mcp_tools.py
+++ b/tests/integration/ai/test_agent_mcp_tools.py
@@ -96,7 +96,7 @@ class TestTools(AITestCase):
             assert tool_message, "No tool message found in response"
             assert tool_message.name == "temperature", "Invalid tool name"
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "31.5" in response, "Invalid LLM response"
 
     @patch(
@@ -219,7 +219,7 @@ class TestTools(AITestCase):
                 ]
             )
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "31.5" in response, "Invalid LLM response"
             assert "30.0" in response, "Invalid LLM response"
             assert "25.5" in response, "Invalid LLM response"
@@ -236,7 +236,7 @@ class TestTools(AITestCase):
                     )
                 ]
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "28.5" in response, "Invalid LLM response"
 
             # Make sure MCP was alive during entire Agent lifetime.
@@ -409,7 +409,7 @@ class TestRemoteTools(AITestCase):
                 assert tool_message, "No tool message found in response"
                 assert tool_message.name == "temperature", "Invalid tool name"
 
-                response = result.final_message.content
+                response = self.parse_content(result.final_message)
                 assert "31.5" in response, "Invalid LLM response"
 
                 assert trace_id == agent.trace_id
@@ -450,7 +450,12 @@ class TestRemoteTools(AITestCase):
                     [HumanMessage(content="What is your name? Answer in one word")]
                 )
 
-                response = result.final_message.content.strip().lower().replace(".", "")
+                response = (
+                    self.parse_content(result.final_message)
+                    .strip()
+                    .lower()
+                    .replace(".", "")
+                )
                 assert "stefan" in response
 
     @patch(
@@ -526,7 +531,7 @@ class TestRemoteTools(AITestCase):
                 assert type(tool_messages[0].result) is ToolFailureResult
                 assert type(tool_messages[1].result) is ToolResult
 
-                response = result.final_message.content
+                response = self.parse_content(result.final_message)
                 assert "31.5" in response, "Invalid LLM response"
 
     @patch(
@@ -630,7 +635,7 @@ class TestRemoteTools(AITestCase):
                         )
                 assert found_tool_message, "missing ToolMessage in agent response"
 
-                response = result.final_message.content
+                response = self.parse_content(result.final_message)
                 assert "31.5" in response, "Invalid LLM response"
 
     @patch(
@@ -692,7 +697,7 @@ class TestRemoteTools(AITestCase):
             assert tool_message, "No tool message found in response"
             assert tool_message.name == "temperature", "Invalid tool name"
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "22" in response, "Invalid LLM response"
 
 

--- a/tests/integration/ai/test_anthropic_agent.py
+++ b/tests/integration/ai/test_anthropic_agent.py
@@ -48,6 +48,11 @@ class TestAnthropicAgent(AITestCase):
                 [HumanMessage(content="What is your name? Answer in one word")]
             )
 
-            response = result.final_message.content.strip().lower().replace(".", "")
+            response = (
+                self.parse_content(result.final_message)
+                .strip()
+                .lower()
+                .replace(".", "")
+            )
             assert result.structured_output is None
             assert "stefan" in response

--- a/tests/integration/ai/test_conversation_store.py
+++ b/tests/integration/ai/test_conversation_store.py
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from pydantic import BaseModel, Field
 import pytest
+from pydantic import BaseModel, Field
 
 from splunklib.ai import Agent
 from splunklib.ai.conversation_store import InMemoryStore
@@ -45,7 +45,7 @@ class TestConversationStore(AITestCase):
 
             result = await agent.invoke([HumanMessage(content="What is my name?")])
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
 
             assert "Chris" not in response, "Agent remembered the name"
 
@@ -103,7 +103,7 @@ class TestConversationStore(AITestCase):
 
             result = await agent.invoke([HumanMessage(content="What is my name?")])
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
 
             assert "Chris" in response, "Agent did not remember the name"
 
@@ -149,7 +149,7 @@ class TestConversationStore(AITestCase):
 
             result = await agent.invoke([HumanMessage(content="What is my name?")])
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
 
             assert "Mike" in response, "Agent did not remember the name"
 
@@ -189,7 +189,7 @@ class TestConversationStore(AITestCase):
                 [HumanMessage(content="What is my name?")],
                 thread_id="2",
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Mike" not in response, (
                 "Agent remembered the name from a different thread_id"
             )
@@ -224,14 +224,14 @@ class TestConversationStore(AITestCase):
                 [HumanMessage(content="What is my name?")],
                 thread_id="2",
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Mike" in response, "Agent did not remember the name"
 
             # When thread_id not specified the one from the agent constructor is used.
             result = await agent.invoke(
                 [HumanMessage(content="What is my name?")],
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Mike" in response, "Agent did not remember the name"
 
         # Now use the same conversation_store in a different agent with same thread_ids.
@@ -247,21 +247,21 @@ class TestConversationStore(AITestCase):
                 [HumanMessage(content="What is my name?")],
                 thread_id="1",
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris" in response, "Agent did not remember the name"
 
             result = await agent.invoke(
                 [HumanMessage(content="What is my name?")],
                 thread_id="2",
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Mike" in response, "Agent did not remember the name"
 
             # When thread_id not specified the one from the agent constructor is used.
             result = await agent.invoke(
                 [HumanMessage(content="What is my name?")],
             )
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Mike" in response, "Agent did not remember the name"
 
 
@@ -333,7 +333,7 @@ class TestSubagentsWithConversationStore(AITestCase):
                 assert isinstance(third_ai_msg.calls[0], SubagentCall)
                 assert thread_id == third_ai_msg.calls[0].thread_id, "missing thread_id"
 
-                assert "chris" in resp.final_message.content.lower()
+                assert "chris" in self.parse_content(resp.final_message).lower()
 
     @pytest.mark.asyncio
     @deterministic_thread_ids()
@@ -408,4 +408,4 @@ class TestSubagentsWithConversationStore(AITestCase):
                 assert isinstance(third_ai_msg.calls[0], SubagentCall)
                 assert thread_id == third_ai_msg.calls[0].thread_id, "invalid thread_id"
 
-                assert "chris" in resp.final_message.content.lower()
+                assert "chris" in self.parse_content(resp.final_message).lower()

--- a/tests/integration/ai/test_hooks.py
+++ b/tests/integration/ai/test_hooks.py
@@ -29,8 +29,14 @@ from splunklib.ai.hooks import (
     before_agent,
     before_model,
 )
-from splunklib.ai.messages import AIMessage, AgentResponse, HumanMessage
-from splunklib.ai.middleware import AgentRequest, ModelMiddlewareHandler, ModelRequest, ModelResponse, model_middleware
+from splunklib.ai.messages import AgentResponse, AIMessage, HumanMessage
+from splunklib.ai.middleware import (
+    AgentRequest,
+    ModelMiddlewareHandler,
+    ModelRequest,
+    ModelResponse,
+    model_middleware,
+)
 from tests.ai_testlib import AITestCase, ai_snapshot_test
 
 
@@ -63,7 +69,7 @@ class TestHook(AITestCase):
             nonlocal hook_calls
             hook_calls += 1
 
-            response = resp.message.content.strip().lower().replace(".", "")
+            response = self.parse_content(resp.message).strip().lower().replace(".", "")
             assert "stefan" == response
 
         @after_model
@@ -71,7 +77,7 @@ class TestHook(AITestCase):
             nonlocal hook_calls
             hook_calls += 1
 
-            response = resp.message.content.strip().lower().replace(".", "")
+            response = self.parse_content(resp.message).strip().lower().replace(".", "")
             assert "stefan" == response
 
         async with Agent(
@@ -93,7 +99,12 @@ class TestHook(AITestCase):
                 ]
             )
 
-            response = result.final_message.content.strip().lower().replace(".", "")
+            response = (
+                self.parse_content(result.final_message)
+                .strip()
+                .lower()
+                .replace(".", "")
+            )
             assert "stefan" == response
             assert hook_calls == 4
 
@@ -161,7 +172,12 @@ class TestHook(AITestCase):
                 ]
             )
 
-            response = result.final_message.content.strip().lower().replace(".", "")
+            response = (
+                self.parse_content(result.final_message)
+                .strip()
+                .lower()
+                .replace(".", "")
+            )
             assert '{"name":"stefan"}' == response
             assert hook_calls == 4
 
@@ -201,10 +217,12 @@ class TestHook(AITestCase):
             with pytest.raises(
                 StepsLimitExceededException, match="Steps limit of 2 exceeded"
             ):
-                _ = await agent.invoke([
-                    HumanMessage(content="hi, my name is Chris"),
-                    HumanMessage(content="What is my name?"),
-                ])
+                _ = await agent.invoke(
+                    [
+                        HumanMessage(content="hi, my name is Chris"),
+                        HumanMessage(content="What is my name?"),
+                    ]
+                )
 
     @pytest.mark.asyncio
     @ai_snapshot_test()
@@ -225,14 +243,18 @@ class TestHook(AITestCase):
             with pytest.raises(
                 StepsLimitExceededException, match="Steps limit of 2 exceeded"
             ):
-                _ = await agent.invoke([
-                    HumanMessage(content="What is my name?"),
-                    HumanMessage(content="Are you sure?"),
-                ])
+                _ = await agent.invoke(
+                    [
+                        HumanMessage(content="What is my name?"),
+                        HumanMessage(content="Are you sure?"),
+                    ]
+                )
 
     @pytest.mark.asyncio
     @ai_snapshot_test()
-    async def test_agent_loop_stop_conditions_steps_accumulate_across_invokes(self) -> None:
+    async def test_agent_loop_stop_conditions_steps_accumulate_across_invokes(
+        self,
+    ) -> None:
         pytest.importorskip("langchain_openai")
 
         step_limit = StepLimitMiddleware(2)

--- a/tests/integration/ai/test_middleware.py
+++ b/tests/integration/ai/test_middleware.py
@@ -96,7 +96,7 @@ class TestMiddleware(AITestCase):
                 [HumanMessage(content="What is the weather like today in Krakow?")]
             )
 
-            response = res.final_message.content
+            response = self.parse_content(res.final_message)
             assert "31.5" in response
             assert middleware_called, "Middleware was not called"
 
@@ -165,7 +165,7 @@ class TestMiddleware(AITestCase):
                 [HumanMessage(content="What is the weather like today in Krakow?")]
             )
 
-            response = res.final_message.content
+            response = self.parse_content(res.final_message)
             assert "31.5" in response
             assert middleware_called, "Middleware was not called"
 
@@ -204,7 +204,7 @@ class TestMiddleware(AITestCase):
                 [HumanMessage(content="What is the weather like today in Kraków?")]
             )
 
-            response = res.final_message.content
+            response = self.parse_content(res.final_message)
             assert "0.5" in response, "Invalid response from LLM"
 
             tool_message = next(
@@ -258,7 +258,7 @@ class TestMiddleware(AITestCase):
             res = await agent.invoke(
                 [HumanMessage(content="What is the weather like today in Krakow?")]
             )
-            assert "31.5" in res.final_message.content
+            assert "31.5" in self.parse_content(res.final_message)
             assert first_called, "First middleware was called after the second"
             assert second_called, "Second middleware was called before the first"
 
@@ -301,7 +301,7 @@ class TestMiddleware(AITestCase):
             res = await agent.invoke(
                 [HumanMessage(content="What is the weather like today in Krakow?")]
             )
-            assert "31.5" in res.final_message.content
+            assert "31.5" in self.parse_content(res.final_message)
             assert tool_called
             assert model_called
 
@@ -356,7 +356,7 @@ class TestMiddleware(AITestCase):
             tool_result = await agent.invoke(
                 [HumanMessage(content="What is the weather like today in Krakow?")]
             )
-            assert "31.5" in tool_result.final_message.content
+            assert "31.5" in self.parse_content(tool_result.final_message)
 
         class NicknameGeneratorInput(BaseModel):
             name: str = Field(description="The person's full name", min_length=1)
@@ -384,7 +384,7 @@ class TestMiddleware(AITestCase):
             subagent_result = await supervisor.invoke(
                 [HumanMessage(content="Generate a nickname for Chris")]
             )
-            assert "Chris-zilla" in subagent_result.final_message.content
+            assert "Chris-zilla" in self.parse_content(subagent_result.final_message)
 
         assert model_called
         assert tool_called
@@ -450,7 +450,7 @@ class TestMiddleware(AITestCase):
             )
             assert subagent_message, "No subagent message found in response"
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris-zilla" in response, "Agent did generate valid nickname"
 
             assert middleware_called, "Middleware was not called"
@@ -501,7 +501,7 @@ class TestMiddleware(AITestCase):
                 [HumanMessage(content="Generate a nickname for Chris")]
             )
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris-superstar" in response, "Invalid response from LLM"
 
             subagent_message = next(
@@ -632,7 +632,7 @@ class TestMiddleware(AITestCase):
                 [HumanMessage(content="Generate a nickname for Chris")]
             )
 
-            response = result.final_message.content
+            response = self.parse_content(result.final_message)
             assert "Chris-zilla" in response, "Agent did generate valid nickname"
             assert middleware_called, "Middleware was not called"
 
@@ -669,7 +669,7 @@ class TestMiddleware(AITestCase):
                 ]
             )
 
-            response = res.final_message.content
+            response = self.parse_content(res.final_message)
             assert "My response is made up" == response
             assert middleware_called, "Middleware was not called"
 
@@ -726,7 +726,7 @@ class TestMiddleware(AITestCase):
             res = await agent.invoke(
                 [HumanMessage(content="What is the capital of Germany?")]
             )
-            assert "Paris" in res.final_message.content
+            assert "Paris" in self.parse_content(res.final_message)
 
     @patch(
         "splunklib.ai.agent._testing_local_tools_path",
@@ -764,7 +764,7 @@ class TestMiddleware(AITestCase):
                 [HumanMessage(content="What is the weather like today in Berlin?")]
             )
             # Berlin returns 22.1C; Krakow returns 31.5C
-            assert "31.5" in res.final_message.content
+            assert "31.5" in self.parse_content(res.final_message)
 
     @pytest.mark.asyncio
     @ai_snapshot_test()
@@ -809,7 +809,7 @@ class TestMiddleware(AITestCase):
             result = await supervisor.invoke(
                 [HumanMessage(content="Generate a nickname for Bob")]
             )
-            assert "Alice-zilla" in result.final_message.content
+            assert "Alice-zilla" in self.parse_content(result.final_message)
 
     @pytest.mark.asyncio
     @ai_snapshot_test()

--- a/tests/integration/ai/test_structured_output.py
+++ b/tests/integration/ai/test_structured_output.py
@@ -305,7 +305,7 @@ class TestStructuredOutput(AITestCase):
                 )
 
                 try:
-                    Person.model_validate_json(e.message.content)
+                    Person.model_validate_json(self.parse_content(e.message))
                     raise AssertionError(
                         "args are valid, but got an StructuredOutputGenerationException"
                     )
@@ -317,7 +317,7 @@ class TestStructuredOutput(AITestCase):
             assert after_first_model_call, "generation error did not happen"
             assert resp.structured_output is not None, "missing structured_output"
             assert (
-                Person.model_validate_json(resp.message.content)
+                Person.model_validate_json(self.parse_content(resp.message))
                 == resp.structured_output
             ), "invalid structured output"
 
@@ -348,7 +348,7 @@ class TestStructuredOutput(AITestCase):
 
             assert len(result.final_message.structured_output_calls) == 0
             assert (
-                Person.model_validate_json(result.final_message.content)
+                Person.model_validate_json(self.parse_content(result.final_message))
                 == result.structured_output
             )
 
@@ -838,7 +838,9 @@ class TestStructuredOutput(AITestCase):
                 assert "ALL letters must be capitalized" in e.error.validation_error
                 assert len(e.message.structured_output_calls) == 0
 
-                args = PersonNotRestricted.model_validate_json(e.message.content)
+                args = PersonNotRestricted.model_validate_json(
+                    self.parse_content(e.message)
+                )
                 args.name = args.name.upper()
 
                 return ModelResponse(

--- a/tests/system/test_apps/ai_agentic_test_app/bin/agentic_endpoint.py
+++ b/tests/system/test_apps/ai_agentic_test_app/bin/agentic_endpoint.py
@@ -21,7 +21,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "lib"))
 from typing import override
 
 from splunklib.ai.agent import Agent
-from splunklib.ai.messages import HumanMessage
+from splunklib.ai.messages import (
+    AIMessage,
+    ContentBlock,
+    HumanMessage,
+    SubagentTextResult,
+    TextBlock,
+)
 from splunklib.ai.tool_settings import ToolSettings
 from tests.cre_testlib import CRETestHandler
 
@@ -58,5 +64,30 @@ class AgentNameHandler(CRETestHandler):
                 [HumanMessage(content="What is your name? Answer in one word")]
             )
 
-            response = result.final_message.content.strip().lower().replace(".", "")
+            response = (
+                self.parse_content(result.final_message)
+                .strip()
+                .lower()
+                .replace(".", "")
+            )
             self.response.write(response)
+
+    def _parse_content_block(self, block: str | ContentBlock) -> str | None:
+        match block:
+            case TextBlock():
+                return block.text
+            case str():
+                return block
+            case _:
+                return None
+
+    def parse_content(self, message: AIMessage | SubagentTextResult) -> str:
+        """Parses the content from AIMessage and builds a single string our of it"""
+        if isinstance(message.content, str):
+            return message.content
+
+        return " ".join(
+            parsed_block
+            for block in message.content
+            if (parsed_block := self._parse_content_block(block))
+        )

--- a/tests/system/test_apps/ai_agentic_test_local_tools_app/bin/agentic_app_tools_endpoint.py
+++ b/tests/system/test_apps/ai_agentic_test_local_tools_app/bin/agentic_app_tools_endpoint.py
@@ -22,7 +22,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "lib"))
 from typing import override
 
 from splunklib.ai.agent import Agent
-from splunklib.ai.messages import HumanMessage
+from splunklib.ai.messages import (
+    AIMessage,
+    ContentBlock,
+    HumanMessage,
+    SubagentTextResult,
+    TextBlock,
+)
 from splunklib.ai.tool_settings import ToolSettings
 from tests.cre_testlib import CRETestHandler
 
@@ -75,5 +81,30 @@ class AgentNameHandler(CRETestHandler):
                 [HumanMessage(content="What is your name? Answer in one word")]
             )
 
-            response = result.final_message.content.strip().lower().replace(".", "")
+            response = (
+                self.parse_content(result.final_message)
+                .strip()
+                .lower()
+                .replace(".", "")
+            )
             self.response.write(response)
+
+    def _parse_content_block(self, block: str | ContentBlock) -> str | None:
+        match block:
+            case TextBlock():
+                return block.text
+            case str():
+                return block
+            case _:
+                return None
+
+    def parse_content(self, message: AIMessage | SubagentTextResult) -> str:
+        """Parses the content from AIMessage and builds a single string our of it"""
+        if isinstance(message.content, str):
+            return message.content
+
+        return " ".join(
+            parsed_block
+            for block in message.content
+            if (parsed_block := self._parse_content_block(block))
+        )

--- a/tests/unit/ai/engine/test_langchain_backend.py
+++ b/tests/unit/ai/engine/test_langchain_backend.py
@@ -30,10 +30,12 @@ from splunklib.ai.engines import langchain as lc
 from splunklib.ai.messages import (
     AIMessage,
     HumanMessage,
+    OpaqueBlock,
     SubagentCall,
     SubagentFailureResult,
     SubagentMessage,
     SystemMessage,
+    TextBlock,
     ToolCall,
     ToolFailureResult,
     ToolMessage,
@@ -55,6 +57,127 @@ class TestMapMessageFromLangchain(unittest.TestCase):
         assert mapped.calls == [
             ToolCall(name="lookup", args={"q": "test"}, id="tc-1", type=ToolType.REMOTE)
         ]
+
+    def test_map_message_from_langchain_ai_with_text_content_block(self) -> None:
+        extras = (
+            {
+                # simulate gemini model returning thought signature in extra field of text content block
+                "signature": "EjQKMgEMOdbHDmsQ+BTM6duYJ43i5npxkpn28Ir0VjD1p6w4fUqIdYszIcWx+XcqAW1a8E+Q"
+            },
+        )
+
+        text_block = {
+            "type": "text",
+            "text": "test-content-block",
+            "id": "some-id",
+            "extras": extras,
+        }
+        message = LC_AIMessage(content=[text_block], tool_calls=[])
+
+        mapped = lc._map_message_from_langchain(message)
+
+        assert isinstance(mapped, AIMessage)
+        assert isinstance(mapped.content[0], TextBlock)
+        assert mapped.content[0].text == "test-content-block"
+        assert mapped.content[0].id == "some-id"
+        assert mapped.content[0].extras == extras
+
+    def test_map_message_from_langchain_ai_with_text_content_block_without_id(
+        self,
+    ) -> None:
+        extras = (
+            {
+                # simulate gemini model returning thought signature in extra field of text content block
+                "signature": "EjQKMgEMOdbHDmsQ+BTM6duYJ43i5npxkpn28Ir0VjD1p6w4fUqIdYszIcWx+XcqAW1a8E+Q"
+            },
+        )
+
+        text_block = {
+            "type": "text",
+            "text": "test-content-block",
+            "extras": extras,
+        }
+        message = LC_AIMessage(content=[text_block], tool_calls=[])
+
+        mapped = lc._map_message_from_langchain(message)
+
+        assert isinstance(mapped, AIMessage)
+        assert isinstance(mapped.content[0], TextBlock)
+        assert mapped.content[0].text == "test-content-block"
+        assert mapped.content[0].id is None
+        assert mapped.content[0].extras == extras
+
+    def test_map_message_from_langchain_ai_with_list_of_str(self) -> None:
+        message = LC_AIMessage(content=["one", "two"], tool_calls=[])
+
+        mapped = lc._map_message_from_langchain(message)
+
+        assert isinstance(mapped, AIMessage)
+        assert mapped.content == ["one", "two"]
+
+    def test_map_message_from_langchain_ai_with_other_content_block(self) -> None:
+        content_block = {
+            "type": "image",
+        }
+        message = LC_AIMessage(content=[content_block], tool_calls=[])
+
+        mapped = lc._map_message_from_langchain(message)
+
+        assert isinstance(mapped, AIMessage)
+        assert isinstance(mapped.content[0], OpaqueBlock)
+        assert mapped.content[0]._data == content_block
+
+    def test_map_message_from_langchain_ai_with_mixed_content(self) -> None:
+        content_block = {
+            "type": "image",
+        }
+        text_block = {
+            "type": "text",
+            "text": "test",
+        }
+        message = LC_AIMessage(
+            content=[content_block, text_block, "test"], tool_calls=[]
+        )
+
+        mapped = lc._map_message_from_langchain(message)
+
+        assert isinstance(mapped, AIMessage)
+        assert isinstance(mapped.content[0], OpaqueBlock)
+        assert mapped.content[0]._data == content_block
+        assert isinstance(mapped.content[1], TextBlock)
+        assert mapped.content[1].text == "test"
+        assert mapped.content[2] == "test"
+
+    def test_map_message_from_langchain_ai_tool_call_with_additional_kwargs(
+        self,
+    ) -> None:
+        tool_call = LC_ToolCall(
+            name=f"__local-startup_time",
+            args={"q": "test"},
+            id="tc-2",
+        )
+        # simulate gemini models returning thought signature in additional kwargs
+        # when calling tools.
+        additional_kwargs = {
+            "function_call": {"name": "__local-startup_time", "arguments": "{}"},
+            "__gemini_function_call_thought_signatures__": {
+                "28e28045-9846-4c9c-ab46-97f33bff5a9c": "EjQKMgEMOdbHH9gTl8BkX2uMM52753GCboanCcnUp9XB896IdThnG42GB8lRSkqGGxVbv5JY"
+            },
+        }
+        message = LC_AIMessage(
+            content="done", tool_calls=[tool_call], additional_kwargs=additional_kwargs
+        )
+        mapped = lc._map_message_from_langchain(message)
+        assert isinstance(mapped, AIMessage)
+        assert mapped.calls == [
+            ToolCall(
+                name="startup_time",
+                args={"q": "test"},
+                id="tc-2",
+                type=ToolType.LOCAL,
+            )
+        ]
+        assert mapped.extras == additional_kwargs
 
     def test_map_message_from_langchain_ai_with_agent_call(self) -> None:
         tool_call = LC_ToolCall(
@@ -159,6 +282,93 @@ class MapMessageToLangchainTests(unittest.TestCase):
         assert mapped.content == "hi"
         assert mapped.tool_calls == [LC_ToolCall(name="lookup", args={}, id="tc-1")]
 
+    def test_map_message_to_langchain_ai_with_text_content_block(self) -> None:
+        extras = {
+            "signature": "EjQKMgEMOdbHDmsQ+BTM6duYJ43i5npxkpn28Ir0VjD1p6w4fUqIdYszIcWx+XcqAW1a8E+Q"
+        }
+        message = AIMessage(
+            content=[
+                TextBlock(
+                    text="test-content-block",
+                    extras=extras,
+                    id="some-id",
+                )
+            ],
+            calls=[],
+        )
+        mapped = lc._map_message_to_langchain(message)
+
+        assert isinstance(mapped, LC_AIMessage)
+        assert isinstance(mapped.content[0], dict)
+        assert mapped.content[0]["type"] == "text"
+        assert mapped.content[0]["text"] == "test-content-block"
+        assert mapped.content[0]["id"] == "some-id"
+        assert mapped.content[0]["extras"] == extras
+
+    def test_map_message_to_langchain_ai_with_text_content_block_no_id(self) -> None:
+        extras = {
+            "signature": "EjQKMgEMOdbHDmsQ+BTM6duYJ43i5npxkpn28Ir0VjD1p6w4fUqIdYszIcWx+XcqAW1a8E+Q"
+        }
+        message = AIMessage(
+            content=[
+                TextBlock(
+                    text="test-content-block",
+                    extras=extras,
+                )
+            ],
+            calls=[],
+        )
+        mapped = lc._map_message_to_langchain(message)
+
+        assert isinstance(mapped, LC_AIMessage)
+        assert isinstance(mapped.content[0], dict)
+        assert mapped.content[0]["type"] == "text"
+        assert mapped.content[0]["text"] == "test-content-block"
+        assert mapped.content[0]["id"] is None
+        assert mapped.content[0]["extras"] == extras
+
+    def test_map_message_to_langchain_ai_with_list_of_str(self) -> None:
+        message = AIMessage(
+            content=["one", "two"],
+            calls=[],
+        )
+        mapped = lc._map_message_to_langchain(message)
+
+        assert isinstance(mapped, LC_AIMessage)
+        assert mapped.content == ["one", "two"]
+
+    def test_map_message_to_langchain_ai_with_opaque_content_block(self) -> None:
+        some_data = {"type": "unsupported"}
+        message = AIMessage(
+            content=[OpaqueBlock(_data=some_data)],
+            calls=[],
+        )
+        mapped = lc._map_message_to_langchain(message)
+
+        assert isinstance(mapped, LC_AIMessage)
+        assert isinstance(mapped.content[0], dict)
+        assert mapped.content[0]["type"] == "unsupported"
+
+    def test_map_message_to_langchain_ai_with_mixed_content_block(self) -> None:
+        some_data = {"type": "unsupported"}
+        message = AIMessage(
+            content=[
+                OpaqueBlock(_data=some_data),
+                TextBlock(text="test-content-block"),
+                "test",
+            ],
+            calls=[],
+        )
+        mapped = lc._map_message_to_langchain(message)
+
+        assert isinstance(mapped, LC_AIMessage)
+        assert isinstance(mapped.content[0], dict)
+        assert mapped.content[0]["type"] == "unsupported"
+        assert isinstance(mapped.content[1], dict)
+        assert mapped.content[1]["type"] == "text"
+        assert mapped.content[1]["text"] == "test-content-block"
+        assert mapped.content[2] == "test"
+
     def test_map_message_to_langchain_ai_with_agent_call(self) -> None:
         message = AIMessage(
             content="hi",
@@ -181,6 +391,42 @@ class MapMessageToLangchainTests(unittest.TestCase):
                 id="tc-2",
             )
         ]
+
+    def test_map_message_to_langchain_ai_with_tool_call_with_thought_signature(
+        self,
+    ) -> None:
+        extras = {
+            "function_call": {
+                "name": "__local-startup_time",
+                "arguments": '{"q": "test"}',
+            },
+            "__gemini_function_call_thought_signatures__": {
+                "28e28045-9846-4c9c-ab46-97f33bff5a9c": "EjQKMgEMOdbHH9gTl8BkX2uMM52753GCboanCcnUp9XB896IdThnG42GB8lRSkqGGxVbv5JY"
+            },
+        }
+        message = AIMessage(
+            content="hi",
+            calls=[
+                ToolCall(
+                    name="startup_time",
+                    args={"q": "test"},
+                    id="tc-2",
+                    type=ToolType.LOCAL,
+                )
+            ],
+            extras=extras,
+        )
+        mapped = lc._map_message_to_langchain(message)
+
+        assert isinstance(mapped, LC_AIMessage)
+        assert mapped.tool_calls == [
+            LC_ToolCall(
+                name=f"__local-startup_time",
+                args={"q": "test"},
+                id="tc-2",
+            )
+        ]
+        assert mapped.additional_kwargs == extras
 
     def test_map_message_to_langchain_human(self) -> None:
         message = HumanMessage(content="hello")


### PR DESCRIPTION
The content of `AIMessage` could differ between different providers.

For example:
* OpenAI gpt-5-nano responds with single string
* Gemini gemini-3-* models respond with list of `content-block`s. Those are dictionaries that include additional information.

An example of Gemini's content-block could look like this:

```
{
    "type": "text",
    "text": "test-content-block",
    "extras": {
          # simulate gemini model returning thought signature in extra field of text content block
          "signature": "EjQKMgEMOdbHDmsQ+BTM6duYJ43i5npxkpn28Ir0VjD1p6w4fUqIdYszIcWx+XcqAW1a8E+Q"
      }
}
```

This content-block contains additional information such as the thought signatures that the Gemini models use.
Additionaly, the Gemini models include the thought signatures in langchain's `AIMessage.additional_kwargs` when issuing a tool call - this is also addressed here by adding an `extras` field to the SDK `AIMessage`.

All those changes should accomodate to the model providers sending additional information along their responses.

> **NOTE**: This change slightly changes the API, since we change the type of `AIMessage.content` from `str` to `str | list[str | ContentBlock]`.
> It also adds new ContentBlock type to note that the response from LLM is structured (not a string).

Currently, only the `TextBlock` is supported, since I didn't see any other one returned from the LLMs I had access to. Other "unsupported" content blocks are stored in `OpaqueBlock`s which are created to persist blocks that are returned by LLM, but not useful for the SDKs. Those would be returned back to the LLM so that the context is preserved. We can add support to other blocks if needed.

The developers should handle possible formats of responses by checking the type or use structured outputs to make sure every model responds with the same format.