### PR TITLE
Use keyed parameters in `SubagentTextResult` constructor

### DIFF
--- a/tests/integration/ai/test_agent_message_validation.py
+++ b/tests/integration/ai/test_agent_message_validation.py
@@ -509,7 +509,7 @@ class TestMessageValidation(AITestCase):
                     SubagentMessage(
                         name="my_agent",
                         call_id="id-1",
-                        result=SubagentTextResult("foo"),
+                        result=SubagentTextResult(content="foo"),
                     ),
                 ],
                 "thread_id should not be an empty string",


### PR DESCRIPTION
I have not rebased #755, but after merge it semantically conflicted with #758.