### PR TITLE
fix: stream records lazily in write_records and _execute_chunk_v2

### DIFF
--- a/splunklib/searchcommands/generating_command.py
+++ b/splunklib/searchcommands/generating_command.py
@@ -208,15 +208,11 @@ class GeneratingCommand(SearchCommand):
 
     def _execute_chunk_v2(self, process, chunk):
         count = 0
-        records = []
         for row in process:
-            records.append(row)
+            self._record_writer.write_record(row)
             count += 1
             if count == self._record_writer._maxresultrows:
                 break
-
-        for row in records:
-            self._record_writer.write_record(row)
 
         if count == self._record_writer._maxresultrows:
             self._finished = False

--- a/splunklib/searchcommands/generating_command.py
+++ b/splunklib/searchcommands/generating_command.py
@@ -211,10 +211,10 @@ class GeneratingCommand(SearchCommand):
         for row in process:
             self._record_writer.write_record(row)
             count += 1
-            if count == self._record_writer._maxresultrows:
+            if count == self._record_writer.maxresultrows:
                 break
 
-        if count == self._record_writer._maxresultrows:
+        if count == self._record_writer.maxresultrows:
             self._finished = False
         else:
             self._finished = True

--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -527,7 +527,8 @@ class RecordWriter:
 
     def write_records(self, records):
         self._ensure_validity()
-        records = [] if records is NotImplemented else list(records)
+        if records is NotImplemented:
+            return
         write_record = self._write_record
         for record in records:
             write_record(record)

--- a/splunklib/searchcommands/internals.py
+++ b/splunklib/searchcommands/internals.py
@@ -463,6 +463,10 @@ class RecordWriter:
         self.custom_fields = set()
 
     @property
+    def maxresultrows(self):
+        return self._maxresultrows
+
+    @property
     def is_flushed(self):
         return self._flushed
 


### PR DESCRIPTION
 Problem:
 `_execute_chunk_v2` was accumulating all records into a list before writing them, causing OOM (out-of-memory) errors when generating commands produced large result sets. Similarly, `write_records` was materializing the full iterator into a list upfront.            
                                                                                                                                     
 Fix:                                                                                                                             
 - In `_execute_chunk_v2:` write each record immediately as it is generated instead of buffering all records first.                   
 - In `write_records`: return early if records is NotImplemented instead of materializing into an empty list.                         
                                                                                                                                     
  This makes both methods stream records lazily, avoiding unnecessary memory allocation.